### PR TITLE
feat(sync): add support for removing individual watches

### DIFF
--- a/projects/api/deno.json
+++ b/projects/api/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@trakt/api",
   "exports": "./src/index.ts",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "imports": {
     "@std/testing": "jsr:@std/testing@^1.0.5",
     "@ts-rest/core": "npm:@ts-rest/core@^3.51.0",

--- a/projects/api/src/contracts/sync/_internal/request/historyIdsRequestSchema.ts
+++ b/projects/api/src/contracts/sync/_internal/request/historyIdsRequestSchema.ts
@@ -1,0 +1,5 @@
+import { z } from '../../../_internal/z.ts';
+
+export const historyIdsRequestSchema = z.object({
+  ids: z.array(z.number()).optional(),
+});

--- a/projects/api/src/contracts/sync/_internal/request/historyRemoveRequestSchema.ts
+++ b/projects/api/src/contracts/sync/_internal/request/historyRemoveRequestSchema.ts
@@ -1,0 +1,5 @@
+import { bulkMediaRequestSchema } from '../../../_internal/request/bulkMediaRequestSchema.ts';
+import { historyIdsRequestSchema } from './historyIdsRequestSchema.ts';
+
+export const historyRemoveRequestSchema = bulkMediaRequestSchema
+  .merge(historyIdsRequestSchema);

--- a/projects/api/src/contracts/sync/_internal/response/historyRemoveResponseSchema.ts
+++ b/projects/api/src/contracts/sync/_internal/response/historyRemoveResponseSchema.ts
@@ -1,7 +1,13 @@
 import { bulkMediaRequestSchema } from '../../../_internal/request/bulkMediaRequestSchema.ts';
 import { z } from '../../../_internal/z.ts';
 
+const historyChangeCountSchema = z.object({
+  movies: z.number(),
+  episodes: z.number(),
+});
+
 export const historyRemoveResponseSchema = z.object({
-  removed: z.object({ movies: z.number(), episodes: z.number() }),
+  added: historyChangeCountSchema,
+  removed: historyChangeCountSchema,
   not_found: bulkMediaRequestSchema,
 });

--- a/projects/api/src/contracts/sync/index.ts
+++ b/projects/api/src/contracts/sync/index.ts
@@ -7,6 +7,7 @@ import { statsQuerySchema } from '../_internal/request/statsQuerySchema.ts';
 import { ratingsResponseSchema } from '../_internal/response/ratingsResponseSchema.ts';
 import type { z } from '../_internal/z.ts';
 import { favoriteParamSchema } from './_internal/request/favoritesParamSchema.ts';
+import { historyRemoveRequestSchema } from './_internal/request/historyRemoveRequestSchema.ts';
 import { ratingsParamSchema } from './_internal/request/ratingsParamSchema.ts';
 import { watchlistRequestSchema } from './_internal/request/watchlistRequestSchema.ts';
 import { favoritesResponseSchema } from './_internal/response/favoritesResponseSchema.ts';
@@ -51,7 +52,7 @@ const history = builder.router({
   remove: {
     method: 'POST',
     path: '/remove',
-    body: bulkMediaRequestSchema,
+    body: historyRemoveRequestSchema,
     responses: {
       200: historyRemoveResponseSchema,
     },
@@ -125,7 +126,8 @@ export const sync = builder.router({
 
 export type UpNextResponse = z.infer<typeof upNextResponseSchema>;
 
-export type HistoryRequest = z.infer<typeof bulkMediaRequestSchema>;
+export type HistoryAddRequest = z.infer<typeof bulkMediaRequestSchema>;
+export type HistoryRemoveRequest = z.infer<typeof historyRemoveRequestSchema>;
 export type HistoryResponse = z.infer<typeof historyResponseSchema>;
 
 export type WatchlistRequest = z.infer<typeof watchlistRequestSchema>;


### PR DESCRIPTION
## 🎶 Notes 🎶

- Add support to remove individual watches.

## 👀 Examples 👀
Before, if you removed a watch, it would remove all plays. In the example below, both of these plays will be removed:
<img width="502" alt="Screenshot 2025-03-10 at 12 19 31" src="https://github.com/user-attachments/assets/443e2396-528d-4e8c-aa5a-109f7c670889" />

With the added support for removing individual plays:
<img width="348" alt="Screenshot 2025-03-10 at 12 19 53" src="https://github.com/user-attachments/assets/d78577a7-5a56-4bbb-afd2-d4a57707e432" />

<img width="484" alt="Screenshot 2025-03-10 at 12 20 07" src="https://github.com/user-attachments/assets/403cbb69-6dae-4dd1-8fae-d7f10bfbfa99" />
