### PR TITLE
Fix/hidden show query param & history items

### DIFF
--- a/projects/api/deno.json
+++ b/projects/api/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@trakt/api",
   "exports": "./src/index.ts",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "imports": {
     "@std/testing": "jsr:@std/testing@^1.0.5",
     "@ts-rest/core": "npm:@ts-rest/core@^3.51.0",

--- a/projects/api/src/contracts/users/_internal/request/hiddenShowRequestSchema.ts
+++ b/projects/api/src/contracts/users/_internal/request/hiddenShowRequestSchema.ts
@@ -1,0 +1,3 @@
+import { z } from '../../../_internal/z.ts';
+
+export const hiddenShowRequestSchema = z.object({ type: z.literal('show') });

--- a/projects/api/src/contracts/users/_internal/request/historyItemIdParamsSchema.ts
+++ b/projects/api/src/contracts/users/_internal/request/historyItemIdParamsSchema.ts
@@ -1,5 +1,5 @@
 import { z } from '../../../_internal/z.ts';
 
 export const historyItemIdParamsSchema = z.object({
-  item_id: z.string().optional(),
+  item_id: z.string(),
 });

--- a/projects/api/src/contracts/users/index.ts
+++ b/projects/api/src/contracts/users/index.ts
@@ -12,6 +12,7 @@ import { z } from '../_internal/z.ts';
 import { searchTypeParamFactory } from '../search/_internal/request/searchTypeParamFactory.ts';
 import { dateRangeParamsSchema } from './_internal/request/dateRangeParamsSchema.ts';
 import { hiddenParamsSchema } from './_internal/request/hiddenParamsSchema.ts';
+import { hiddenShowRequestSchema } from './_internal/request/hiddenShowRequestSchema.ts';
 import { historyItemIdParamsSchema } from './_internal/request/historyItemIdParamsSchema.ts';
 import { listParamsSchema } from './_internal/request/listParamsSchema.ts';
 import { profileParamsSchema } from './_internal/request/profileParamsSchema.ts';
@@ -271,14 +272,13 @@ export const users = builder.router({
       },
     },
     get: {
-      shows: {
-        path: '/hidden/progress_watched?type=show',
-        method: 'GET',
-        query: extendedQuerySchemaFactory<['full', 'images']>()
-          .merge(pageQuerySchema),
-        responses: {
-          200: hiddenShowResponseSchema.array(),
-        },
+      path: '/hidden/progress_watched',
+      method: 'GET',
+      query: extendedQuerySchemaFactory<['full', 'images']>()
+        .merge(pageQuerySchema)
+        .merge(hiddenShowRequestSchema),
+      responses: {
+        200: hiddenShowResponseSchema.array(),
       },
     },
     remove: {

--- a/projects/api/src/contracts/users/index.ts
+++ b/projects/api/src/contracts/users/index.ts
@@ -97,7 +97,40 @@ export const users = builder.router({
       },
     },
     movies: {
-      path: '/movies/:item_id?',
+      path: '/movies',
+      method: 'GET',
+      pathParams: profileParamsSchema,
+      query: extendedQuerySchemaFactory<['full', 'images']>()
+        .merge(dateRangeParamsSchema)
+        .merge(pageQuerySchema),
+      responses: {
+        200: movieActivityHistoryResponseSchema.array(),
+      },
+    },
+    shows: {
+      path: '/shows',
+      method: 'GET',
+      pathParams: profileParamsSchema,
+      query: extendedQuerySchemaFactory<['full', 'images']>()
+        .merge(dateRangeParamsSchema)
+        .merge(pageQuerySchema),
+      responses: {
+        200: showActivityHistoryResponseSchema.array(),
+      },
+    },
+    episodes: {
+      path: '/episodes',
+      method: 'GET',
+      pathParams: profileParamsSchema,
+      query: extendedQuerySchemaFactory<['full', 'images']>()
+        .merge(dateRangeParamsSchema)
+        .merge(pageQuerySchema),
+      responses: {
+        200: episodeActivityHistoryResponseSchema.array(),
+      },
+    },
+    movie: {
+      path: '/movies/:item_id',
       method: 'GET',
       pathParams: profileParamsSchema
         .merge(historyItemIdParamsSchema),
@@ -108,8 +141,8 @@ export const users = builder.router({
         200: movieActivityHistoryResponseSchema.array(),
       },
     },
-    shows: {
-      path: '/shows/:item_id?',
+    show: {
+      path: '/shows/:item_id',
       method: 'GET',
       pathParams: profileParamsSchema
         .merge(historyItemIdParamsSchema),
@@ -120,8 +153,8 @@ export const users = builder.router({
         200: showActivityHistoryResponseSchema.array(),
       },
     },
-    episodes: {
-      path: '/episodes/:item_id?',
+    episode: {
+      path: '/episodes/:item_id',
       method: 'GET',
       pathParams: profileParamsSchema
         .merge(historyItemIdParamsSchema),


### PR DESCRIPTION
## 🎶 Notes 🎶

- Moves hidden show query param from path to query.
- Adds explicit endpoints for getting watch history of individual items.
  - Might revert it in the future; for now I couldn't figure out while the previous solution didn't work on consumer level, while it did work in the playground 🤔

## 👀 Examples 👀
Before/after:
<img width="687" alt="Screenshot 2025-03-11 at 21 08 32" src="https://github.com/user-attachments/assets/aff175fa-6e25-4762-925c-1c29cdecb74b" />

<img width="687" alt="Screenshot 2025-03-11 at 21 07 07" src="https://github.com/user-attachments/assets/65248a12-ad90-40ec-ba11-1203434bc15e" />

Before/after:
<img width="732" alt="Screenshot 2025-03-12 at 09 53 59" src="https://github.com/user-attachments/assets/b2228c47-2f48-4b71-b209-d85daedf7072" />

<img width="732" alt="Screenshot 2025-03-12 at 09 53 02" src="https://github.com/user-attachments/assets/407b12fa-bec5-418e-90f2-873e6eb2db5a" />
