### PR TITLE
feat / add support for relevant endpoints to request extended colors

### DIFF
--- a/projects/api/src/contracts/_internal/response/mediaColorsResponseSchema.ts
+++ b/projects/api/src/contracts/_internal/response/mediaColorsResponseSchema.ts
@@ -1,0 +1,5 @@
+import { z } from '../z.ts';
+
+export const mediaColorsResponseSchema = z.object({
+  poster: z.array(z.string()),
+});

--- a/projects/api/src/contracts/_internal/response/movieResponseSchema.ts
+++ b/projects/api/src/contracts/_internal/response/movieResponseSchema.ts
@@ -1,6 +1,7 @@
 import { z } from '../z.ts';
 import { genreResponseSchema } from './genreResponseSchema.ts';
 import { imagesResponseSchema } from './imagesResponseSchema.ts';
+import { mediaColorsResponseSchema } from './mediaColorsResponseSchema.ts';
 import { movieCertificationResponseSchema } from './movieCertificationResponseSchema.ts';
 import { movieIdsResponseSchema } from './movieIdsResponseSchema.ts';
 import { statusResponseSchema } from './statusResponseSchema.ts';
@@ -86,4 +87,8 @@ export const movieResponseSchema = z.object({
    * Available if requesting extended `full`.
    */
   original_title: z.string().nullish(),
+  /***
+   * Available if requesting extended `colors`.
+   */
+  colors: mediaColorsResponseSchema.optional(),
 });

--- a/projects/api/src/contracts/_internal/response/showResponseSchema.ts
+++ b/projects/api/src/contracts/_internal/response/showResponseSchema.ts
@@ -1,6 +1,7 @@
 import { z } from '../z.ts';
 import { genreResponseSchema } from './genreResponseSchema.ts';
 import { imagesResponseSchema } from './imagesResponseSchema.ts';
+import { mediaColorsResponseSchema } from './mediaColorsResponseSchema.ts';
 import { showCertificationResponseSchema } from './showCertificationResponseSchema.ts';
 import { showIdsResponseSchema } from './showIdsResponseSchema.ts';
 import { statusResponseSchema } from './statusResponseSchema.ts';
@@ -101,4 +102,8 @@ export const showResponseSchema = z.object({
    * Available if requesting extended `full`.
    */
   original_title: z.string().nullish(),
+  /***
+   * Available if requesting extended `colors`.
+   */
+  colors: mediaColorsResponseSchema.optional(),
 });

--- a/projects/api/src/contracts/movies/index.ts
+++ b/projects/api/src/contracts/movies/index.ts
@@ -43,7 +43,7 @@ const ENTITY_LEVEL = builder.router({
   summary: {
     path: '',
     method: 'GET',
-    query: extendedQuerySchemaFactory<['full', 'images']>(),
+    query: extendedQuerySchemaFactory<['full', 'images', 'colors']>(),
     pathParams: idParamsSchema,
     responses: {
       200: movieResponseSchema,
@@ -156,7 +156,7 @@ const GLOBAL_LEVEL = builder.router({
   trending: {
     path: '/trending',
     method: 'GET',
-    query: extendedQuerySchemaFactory<['full', 'images']>()
+    query: extendedQuerySchemaFactory<['full', 'images', 'colors']>()
       .merge(pageQuerySchema)
       .merge(ignoreQuerySchema),
     responses: {
@@ -166,7 +166,7 @@ const GLOBAL_LEVEL = builder.router({
   watched: {
     path: '/watched/:period',
     method: 'GET',
-    query: extendedQuerySchemaFactory<['full', 'images']>()
+    query: extendedQuerySchemaFactory<['full', 'images', 'colors']>()
       .merge(pageQuerySchema)
       .merge(ignoreQuerySchema),
     pathParams: periodParamsSchema,
@@ -177,7 +177,7 @@ const GLOBAL_LEVEL = builder.router({
   anticipated: {
     path: '/anticipated',
     method: 'GET',
-    query: extendedQuerySchemaFactory<['full', 'images']>()
+    query: extendedQuerySchemaFactory<['full', 'images', 'colors']>()
       .merge(pageQuerySchema)
       .merge(ignoreQuerySchema),
     responses: {
@@ -187,7 +187,7 @@ const GLOBAL_LEVEL = builder.router({
   popular: {
     path: '/popular',
     method: 'GET',
-    query: extendedQuerySchemaFactory<['full', 'images']>()
+    query: extendedQuerySchemaFactory<['full', 'images', 'colors']>()
       .merge(pageQuerySchema)
       .merge(ignoreQuerySchema),
     responses: {
@@ -198,7 +198,7 @@ const GLOBAL_LEVEL = builder.router({
     path: '/streaming/:period',
     method: 'GET',
     pathParams: recentPeriodParamsSchema,
-    query: extendedQuerySchemaFactory<['full', 'images']>()
+    query: extendedQuerySchemaFactory<['full', 'images', 'colors']>()
       .merge(streamingParamsSchema)
       .merge(pageQuerySchema)
       .merge(ignoreQuerySchema),

--- a/projects/api/src/contracts/recommendations/index.ts
+++ b/projects/api/src/contracts/recommendations/index.ts
@@ -10,7 +10,7 @@ const movies = builder.router({
   recommend: {
     path: '/',
     method: 'GET',
-    query: extendedQuerySchemaFactory<['full', 'images']>()
+    query: extendedQuerySchemaFactory<['full', 'images', 'colors']>()
       .merge(recommendationsQuerySchema),
     responses: {
       200: recommendedMovieResponse,
@@ -30,7 +30,7 @@ const shows = builder.router({
   recommend: {
     path: '/',
     method: 'GET',
-    query: extendedQuerySchemaFactory<['full', 'images']>()
+    query: extendedQuerySchemaFactory<['full', 'images', 'colors']>()
       .merge(recommendationsQuerySchema),
     responses: {
       200: recommendedShowResponse,

--- a/projects/api/src/contracts/shows/index.ts
+++ b/projects/api/src/contracts/shows/index.ts
@@ -135,7 +135,7 @@ const ENTITY_LEVEL = builder.router({
   summary: {
     path: '',
     method: 'GET',
-    query: extendedQuerySchemaFactory<['full', 'images']>(),
+    query: extendedQuerySchemaFactory<['full', 'images', 'colors']>(),
     pathParams: idParamsSchema,
     responses: {
       200: showResponseSchema,
@@ -281,7 +281,7 @@ const GLOBAL_LEVEL = builder.router({
   trending: {
     path: '/trending',
     method: 'GET',
-    query: extendedQuerySchemaFactory<['full', 'images']>()
+    query: extendedQuerySchemaFactory<['full', 'images', 'colors']>()
       .merge(pageQuerySchema)
       .merge(ignoreQuerySchema),
     responses: {
@@ -291,7 +291,7 @@ const GLOBAL_LEVEL = builder.router({
   watched: {
     path: '/watched/:period',
     method: 'GET',
-    query: extendedQuerySchemaFactory<['full', 'images']>()
+    query: extendedQuerySchemaFactory<['full', 'images', 'colors']>()
       .merge(pageQuerySchema)
       .merge(ignoreQuerySchema),
     pathParams: periodParamsSchema,
@@ -302,7 +302,7 @@ const GLOBAL_LEVEL = builder.router({
   anticipated: {
     path: '/anticipated',
     method: 'GET',
-    query: extendedQuerySchemaFactory<['full', 'images']>()
+    query: extendedQuerySchemaFactory<['full', 'images', 'colors']>()
       .merge(pageQuerySchema)
       .merge(ignoreQuerySchema),
     responses: {
@@ -312,7 +312,7 @@ const GLOBAL_LEVEL = builder.router({
   popular: {
     path: '/popular',
     method: 'GET',
-    query: extendedQuerySchemaFactory<['full', 'images']>()
+    query: extendedQuerySchemaFactory<['full', 'images', 'colors']>()
       .merge(pageQuerySchema)
       .merge(ignoreQuerySchema),
     responses: {
@@ -323,7 +323,7 @@ const GLOBAL_LEVEL = builder.router({
     path: '/streaming/:period',
     method: 'GET',
     pathParams: recentPeriodParamsSchema,
-    query: extendedQuerySchemaFactory<['full', 'images']>()
+    query: extendedQuerySchemaFactory<['full', 'images', 'colors']>()
       .merge(streamingParamsSchema)
       .merge(pageQuerySchema)
       .merge(ignoreQuerySchema),


### PR DESCRIPTION
This pull request makes several updates to the query schemas across multiple endpoints for movies, shows, and recommendations to include the 'colors' field. The changes ensure that the 'colors' field is now part of the extended query schema in various API routes.

Schema updates:

* [`projects/api/src/contracts/movies/index.ts`](diffhunk://#diff-181ea4191a699af2ca7acd72ca848efc9f23268923cc7500302fe91ba05dec46L46-R46): Added 'colors' to the query schema in multiple endpoints including `summary`, `trending`, `watched`, `anticipated`, `popular`, and `streaming`. [[1]](diffhunk://#diff-181ea4191a699af2ca7acd72ca848efc9f23268923cc7500302fe91ba05dec46L46-R46) [[2]](diffhunk://#diff-181ea4191a699af2ca7acd72ca848efc9f23268923cc7500302fe91ba05dec46L159-R159) [[3]](diffhunk://#diff-181ea4191a699af2ca7acd72ca848efc9f23268923cc7500302fe91ba05dec46L169-R169) [[4]](diffhunk://#diff-181ea4191a699af2ca7acd72ca848efc9f23268923cc7500302fe91ba05dec46L180-R180) [[5]](diffhunk://#diff-181ea4191a699af2ca7acd72ca848efc9f23268923cc7500302fe91ba05dec46L190-R190) [[6]](diffhunk://#diff-181ea4191a699af2ca7acd72ca848efc9f23268923cc7500302fe91ba05dec46L201-R201)
* [`projects/api/src/contracts/recommendations/index.ts`](diffhunk://#diff-64633d2c5a79c561148bdfa957528b3328cbff3a7007b81351e6023c669c7d7aL13-R13): Added 'colors' to the query schema in both `movies` and `shows` recommendation endpoints. [[1]](diffhunk://#diff-64633d2c5a79c561148bdfa957528b3328cbff3a7007b81351e6023c669c7d7aL13-R13) [[2]](diffhunk://#diff-64633d2c5a79c561148bdfa957528b3328cbff3a7007b81351e6023c669c7d7aL33-R33)
* [`projects/api/src/contracts/shows/index.ts`](diffhunk://#diff-4b28829c03a747436bb3bc5d5109bc8a56c982f2b171400cc8c397644268eb0aL45-R45): Added 'colors' to the query schema in multiple endpoints including `summary`, `trending`, `watched`, `anticipated`, `popular`, and `streaming`. [[1]](diffhunk://#diff-4b28829c03a747436bb3bc5d5109bc8a56c982f2b171400cc8c397644268eb0aL45-R45) [[2]](diffhunk://#diff-4b28829c03a747436bb3bc5d5109bc8a56c982f2b171400cc8c397644268eb0aL284-R284) [[3]](diffhunk://#diff-4b28829c03a747436bb3bc5d5109bc8a56c982f2b171400cc8c397644268eb0aL294-R294) [[4]](diffhunk://#diff-4b28829c03a747436bb3bc5d5109bc8a56c982f2b171400cc8c397644268eb0aL305-R305) [[5]](diffhunk://#diff-4b28829c03a747436bb3bc5d5109bc8a56c982f2b171400cc8c397644268eb0aL315-R315) [[6]](diffhunk://#diff-4b28829c03a747436bb3bc5d5109bc8a56c982f2b171400cc8c397644268eb0aL326-R326)