### PR TITLE
feat(recommendation): define experimental social endpoints

### DIFF
--- a/projects/api/deno.json
+++ b/projects/api/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@trakt/api",
   "exports": "./src/index.ts",
-  "version": "0.1.21",
+  "version": "0.1.22",
   "imports": {
     "@std/testing": "jsr:@std/testing@^1.0.5",
     "@ts-rest/core": "npm:@ts-rest/core@^3.51.0",

--- a/projects/api/src/contracts/social_recommendations/index.ts
+++ b/projects/api/src/contracts/social_recommendations/index.ts
@@ -1,0 +1,36 @@
+import { builder } from '../_internal/builder.ts';
+import { extendedQuerySchemaFactory } from '../_internal/request/extendedQuerySchemaFactory.ts';
+import { recommendationsQuerySchema } from '../recommendations/_internal/request/recommendationsQuerySchema.ts';
+import { recommendedMovieResponse } from '../recommendations/_internal/response/recommendedMovieResponse.ts';
+import { recommendedShowResponse } from '../recommendations/_internal/response/recommendedShowResponse.ts';
+
+const movies = builder.router({
+  recommend: {
+    path: '/',
+    method: 'GET',
+    query: extendedQuerySchemaFactory<['full', 'images', 'colors']>()
+      .merge(recommendationsQuerySchema),
+    responses: {
+      200: recommendedMovieResponse,
+    },
+  },
+}, { pathPrefix: '/movies' });
+
+const shows = builder.router({
+  recommend: {
+    path: '/',
+    method: 'GET',
+    query: extendedQuerySchemaFactory<['full', 'images', 'colors']>()
+      .merge(recommendationsQuerySchema),
+    responses: {
+      200: recommendedShowResponse,
+    },
+  },
+}, { pathPrefix: '/shows' });
+
+export const social_recommendations = builder.router({
+  movies,
+  shows,
+}, {
+  pathPrefix: '/social_recommendations',
+});

--- a/projects/api/src/contracts/traktContract.ts
+++ b/projects/api/src/contracts/traktContract.ts
@@ -12,6 +12,7 @@ import { recommendations } from './recommendations/index.ts';
 import { scrobble } from './scrobble/index.ts';
 import { search } from './search/index.ts';
 import { shows } from './shows/index.ts';
+import { social_recommendations } from './social_recommendations/index.ts';
 import { sync } from './sync/index.ts';
 import { users } from './users/index.ts';
 import { watchnow } from './watchnow/index.ts';
@@ -24,6 +25,7 @@ export const traktContract = builder
     users,
     sync,
     recommendations,
+    social_recommendations,
     movies,
     shows,
     search,


### PR DESCRIPTION
This pull request introduces a new API module for social recommendations, adding endpoints for recommending movies and shows. The changes define routers for handling these recommendations with specific query schemas and response formats.

### New API module for social recommendations:
* [`projects/api/src/contracts/social_recommendations/index.ts`](diffhunk://#diff-473485ff0937ed98adf810fdb0a5dcfd96aa0d45b64583282e2c0ded274732e5R1-R36): Added a `recommendations` router with two sub-routers, `movies` and `shows`, each supporting a `GET` endpoint for recommendations. These endpoints use `extendedQuerySchemaFactory` to define query parameters and return responses formatted as `recommendedMovieResponse` or `recommendedShowResponse`.