### PR TITLE
feat / add videos endpoint for movies and shows

### DIFF
--- a/projects/api/src/contracts/_internal/response/videoResponseSchema.ts
+++ b/projects/api/src/contracts/_internal/response/videoResponseSchema.ts
@@ -1,0 +1,13 @@
+import { z } from 'zod';
+
+export const videoResponseSchema = z.object({
+  title: z.string(),
+  url: z.string(),
+  site: z.string(),
+  type: z.enum(['recap', 'featurette', 'teaser']),
+  size: z.number(),
+  official: z.boolean(),
+  published_at: z.string(),
+  country: z.string(),
+  language: z.string(),
+});

--- a/projects/api/src/contracts/models/index.ts
+++ b/projects/api/src/contracts/models/index.ts
@@ -15,6 +15,7 @@ import type { sentimentsResponseSchema } from '../_internal/response/sentimentsR
 import type { statusResponseSchema } from '../_internal/response/statusResponseSchema.ts';
 import type { studioResponseSchema } from '../_internal/response/studioResponseSchema.ts';
 import type { translationResponseSchema } from '../_internal/response/translationResponseSchema.ts';
+import type { videoResponseSchema } from '../_internal/response/videoResponseSchema.ts';
 import type { watchNowResponseSchema } from '../_internal/response/watchNowResponseSchema.ts';
 import type { z } from '../_internal/z.ts';
 
@@ -47,3 +48,4 @@ export type TranslationResponse = z.infer<
 >;
 export type ProfileResponse = z.infer<typeof profileResponseSchema>;
 export type WatchNowResponse = z.infer<typeof watchNowResponseSchema>;
+export type VideoResponse = z.infer<typeof videoResponseSchema>;

--- a/projects/api/src/contracts/movies/index.ts
+++ b/projects/api/src/contracts/movies/index.ts
@@ -28,6 +28,7 @@ import { ratingsResponseSchema } from '../_internal/response/ratingsResponseSche
 import { sentimentsResponseSchema } from '../_internal/response/sentimentsResponseSchema.ts';
 import { studioResponseSchema } from '../_internal/response/studioResponseSchema.ts';
 import { translationResponseSchema } from '../_internal/response/translationResponseSchema.ts';
+import { videoResponseSchema } from '../_internal/response/videoResponseSchema.ts';
 import {
   watchNowResponseSchema,
   type watchNowServiceResponseSchema,
@@ -116,6 +117,15 @@ const ENTITY_LEVEL = builder.router({
     pathParams: idParamsSchema,
     responses: {
       200: peopleResponseSchema,
+    },
+  },
+  videos: {
+    path: '/videos',
+    method: 'GET',
+    query: extendedQuerySchemaFactory<['full', 'images']>(),
+    pathParams: idParamsSchema,
+    responses: {
+      200: videoResponseSchema.array(),
     },
   },
   lists: {

--- a/projects/api/src/contracts/shows/index.ts
+++ b/projects/api/src/contracts/shows/index.ts
@@ -27,6 +27,7 @@ import { showResponseSchema } from '../_internal/response/showResponseSchema.ts'
 import { showStatsResponseSchema } from '../_internal/response/showStatsResponseSchema.ts';
 import { studioResponseSchema } from '../_internal/response/studioResponseSchema.ts';
 import { translationResponseSchema } from '../_internal/response/translationResponseSchema.ts';
+import { videoResponseSchema } from '../_internal/response/videoResponseSchema.ts';
 import { watchNowResponseSchema } from '../_internal/response/watchNowResponseSchema.ts';
 import type { z } from '../_internal/z.ts';
 import { episodeParamsSchema } from './_internal/request/episodeParamsSchema.ts';
@@ -235,14 +236,37 @@ const ENTITY_LEVEL = builder.router({
       200: seasonResponseSchema.array(),
     },
   },
-  episodes: {
-    path: '/seasons/:season',
+  season: builder.router({
+    episodes: {
+      path: '',
+      method: 'GET',
+      query: extendedQuerySchemaFactory<['full', 'images']>(),
+      pathParams: idParamsSchema
+        .merge(seasonParamsSchema),
+      responses: {
+        200: episodeResponseSchema.array(),
+      },
+    },
+    videos: {
+      path: '/seasons/:season/videos',
+      method: 'GET',
+      query: extendedQuerySchemaFactory<['full', 'images']>(),
+      pathParams: idParamsSchema
+        .merge(seasonParamsSchema),
+      responses: {
+        200: videoResponseSchema.array(),
+      },
+    },
+  }, {
+    pathPrefix: '/seasons/:season',
+  }),
+  videos: {
+    path: '/videos',
     method: 'GET',
     query: extendedQuerySchemaFactory<['full', 'images']>(),
-    pathParams: idParamsSchema
-      .merge(seasonParamsSchema),
+    pathParams: idParamsSchema,
     responses: {
-      200: episodeResponseSchema.array(),
+      200: videoResponseSchema.array(),
     },
   },
   lists: {


### PR DESCRIPTION
This pull request introduces a new `videoResponseSchema` and integrates it into the API contracts for movies and shows. The changes include the creation of the schema, updates to the import statements, and the addition of new endpoints for retrieving video-related data.

### Schema Definition:
* Created `videoResponseSchema` in `projects/api/src/contracts/_internal/response/videoResponseSchema.ts`, defining the structure for video-related responses, including fields like `title`, `url`, `type`, and `published_at`.

### Integration with Movies API:
* Imported `videoResponseSchema` into `projects/api/src/contracts/movies/index.ts`.
* Added a new endpoint `/videos` in the movies API to fetch video data, returning an array of `videoResponseSchema` objects.

### Integration with Shows API:
* Imported `videoResponseSchema` into `projects/api/src/contracts/shows/index.ts`.
* Added a `/seasons/:season/videos` endpoint under the shows API, scoped to specific seasons, and returning an array of `videoResponseSchema` objects.
* Introduced a top-level `/videos` endpoint in the shows API for fetching video data.
* Defined a new `VideoResponse` type based on `videoResponseSchema` for use in the shows API.