### PR TITLE
feat: define global media filter param schema

### DIFF
--- a/projects/api/src/contracts/_internal/request/mediaFilterParamsSchema.ts
+++ b/projects/api/src/contracts/_internal/request/mediaFilterParamsSchema.ts
@@ -1,0 +1,8 @@
+import { z } from '../z.ts';
+
+export const mediaFilterParamsSchema = z.object({
+  watchnow: z.enum(['favorites', 'any']).optional(),
+  genres: z.string().optional(),
+  years: z.string().optional(),
+  ratings: z.string().optional(),
+});

--- a/projects/api/src/contracts/_internal/request/streamingParamsSchema.ts
+++ b/projects/api/src/contracts/_internal/request/streamingParamsSchema.ts
@@ -1,5 +1,0 @@
-import { z } from '../z.ts';
-
-export const streamingParamsSchema = z.object({
-  watchnow: z.literal('favorites').optional(),
-});

--- a/projects/api/src/contracts/lists/index.ts
+++ b/projects/api/src/contracts/lists/index.ts
@@ -2,6 +2,7 @@ import { builder } from '../_internal/builder.ts';
 import { extendedQuerySchemaFactory } from '../_internal/request/extendedQuerySchemaFactory.ts';
 import { idParamsSchema } from '../_internal/request/idParamsSchema.ts';
 import { limitlessQuerySchema } from '../_internal/request/limitlessQuerySchema.ts';
+import { mediaFilterParamsSchema } from '../_internal/request/mediaFilterParamsSchema.ts';
 import { pageQuerySchema } from '../_internal/request/pageQuerySchema.ts';
 import { likeResponseSchema } from '../_internal/response/likeResponseSchema.ts';
 import { listedMovieResponseSchema } from '../_internal/response/listedMovieResponseSchema.ts';
@@ -16,7 +17,9 @@ const ENTITY_LEVEL = builder.router({
     path: '',
     method: 'GET',
     pathParams: idParamsSchema,
-    query: extendedQuerySchemaFactory<['full', 'images']>(),
+    query: extendedQuerySchemaFactory<['full', 'images']>()
+      /** NOTE: technically not supported yet */
+      .merge(mediaFilterParamsSchema),
     responses: {
       200: listResponseSchema,
     },
@@ -31,6 +34,8 @@ const ENTITY_LEVEL = builder.router({
         >(),
       ),
     query: extendedQuerySchemaFactory<['full', 'images']>()
+      /** NOTE: technically not supported yet */
+      .merge(mediaFilterParamsSchema)
       .and(pageQuerySchema.or(limitlessQuerySchema)),
     responses: {
       200: z.union([listedMovieResponseSchema, listedShowResponseSchema])
@@ -73,7 +78,9 @@ const GLOBAL_LEVEL = builder.router({
     path: '/trending',
     method: 'GET',
     query: extendedQuerySchemaFactory<['full']>()
-      .merge(pageQuerySchema),
+      .merge(pageQuerySchema)
+      /** NOTE: technically not supported yet */
+      .merge(mediaFilterParamsSchema),
     responses: {
       200: prominentListResponseSchema.array(),
     },
@@ -82,7 +89,9 @@ const GLOBAL_LEVEL = builder.router({
     path: '/popular',
     method: 'GET',
     query: extendedQuerySchemaFactory<['full']>()
-      .merge(pageQuerySchema),
+      .merge(pageQuerySchema)
+      /** NOTE: technically not supported yet */
+      .merge(mediaFilterParamsSchema),
     responses: {
       200: prominentListResponseSchema.array(),
     },

--- a/projects/api/src/contracts/movies/index.ts
+++ b/projects/api/src/contracts/movies/index.ts
@@ -6,10 +6,10 @@ import { ignoreQuerySchema } from '../_internal/request/ignoreQuerySchema.ts';
 import { languageParamsSchema } from '../_internal/request/languageParamsSchema.ts';
 import { limitlessQuerySchema } from '../_internal/request/limitlessQuerySchema.ts';
 import { linksQuerySchema } from '../_internal/request/linksQuerySchema.ts';
+import { mediaFilterParamsSchema } from '../_internal/request/mediaFilterParamsSchema.ts';
 import { pageQuerySchema } from '../_internal/request/pageQuerySchema.ts';
 import { periodParamsSchema } from '../_internal/request/periodParamsSchema.ts';
 import { recentPeriodParamsSchema } from '../_internal/request/recentPeriodParamsSchema.ts';
-import { streamingParamsSchema } from '../_internal/request/streamingParamsSchema.ts';
 import { commentResponseSchema } from '../_internal/response/commentResponseSchema.ts';
 import type { genreEnumSchema } from '../_internal/response/genreEnumSchema.ts';
 import { listResponseSchema } from '../_internal/response/listResponseSchema.ts';
@@ -167,6 +167,7 @@ const GLOBAL_LEVEL = builder.router({
     path: '/trending',
     method: 'GET',
     query: extendedQuerySchemaFactory<['full', 'images', 'colors']>()
+      .merge(mediaFilterParamsSchema)
       .merge(pageQuerySchema)
       .merge(ignoreQuerySchema),
     responses: {
@@ -188,6 +189,7 @@ const GLOBAL_LEVEL = builder.router({
     path: '/anticipated',
     method: 'GET',
     query: extendedQuerySchemaFactory<['full', 'images', 'colors']>()
+      .merge(mediaFilterParamsSchema)
       .merge(pageQuerySchema)
       .merge(ignoreQuerySchema),
     responses: {
@@ -198,6 +200,7 @@ const GLOBAL_LEVEL = builder.router({
     path: '/popular',
     method: 'GET',
     query: extendedQuerySchemaFactory<['full', 'images', 'colors']>()
+      .merge(mediaFilterParamsSchema)
       .merge(pageQuerySchema)
       .merge(ignoreQuerySchema),
     responses: {
@@ -209,7 +212,7 @@ const GLOBAL_LEVEL = builder.router({
     method: 'GET',
     pathParams: recentPeriodParamsSchema,
     query: extendedQuerySchemaFactory<['full', 'images', 'colors']>()
-      .merge(streamingParamsSchema)
+      .merge(mediaFilterParamsSchema)
       .merge(pageQuerySchema)
       .merge(ignoreQuerySchema),
     responses: {

--- a/projects/api/src/contracts/recommendations/_internal/request/recommendationsQuerySchema.ts
+++ b/projects/api/src/contracts/recommendations/_internal/request/recommendationsQuerySchema.ts
@@ -4,7 +4,4 @@ import { z } from '../../../_internal/z.ts';
 export const recommendationsQuerySchema = z.object({
   limit: z.number().optional(),
   watch_window: z.number().optional(),
-  genres: z.string().optional(),
-  decade: z.number().optional(),
-  min_year: z.number().optional(),
 }).merge(ignoreQuerySchema);

--- a/projects/api/src/contracts/recommendations/index.ts
+++ b/projects/api/src/contracts/recommendations/index.ts
@@ -1,5 +1,6 @@
 import { builder } from '../_internal/builder.ts';
 import { extendedQuerySchemaFactory } from '../_internal/request/extendedQuerySchemaFactory.ts';
+import { mediaFilterParamsSchema } from '../_internal/request/mediaFilterParamsSchema.ts';
 import { z } from '../_internal/z.ts';
 import { hideParamsSchema } from './_internal/request/hideParamsSchema.ts';
 import { recommendationsQuerySchema } from './_internal/request/recommendationsQuerySchema.ts';
@@ -11,7 +12,8 @@ const movies = builder.router({
     path: '/',
     method: 'GET',
     query: extendedQuerySchemaFactory<['full', 'images', 'colors']>()
-      .merge(recommendationsQuerySchema),
+      .merge(recommendationsQuerySchema)
+      .merge(mediaFilterParamsSchema),
     responses: {
       200: recommendedMovieResponse,
     },
@@ -31,7 +33,8 @@ const shows = builder.router({
     path: '/',
     method: 'GET',
     query: extendedQuerySchemaFactory<['full', 'images', 'colors']>()
-      .merge(recommendationsQuerySchema),
+      .merge(recommendationsQuerySchema)
+      .merge(mediaFilterParamsSchema),
     responses: {
       200: recommendedShowResponse,
     },

--- a/projects/api/src/contracts/shows/index.ts
+++ b/projects/api/src/contracts/shows/index.ts
@@ -6,11 +6,11 @@ import { ignoreQuerySchema } from '../_internal/request/ignoreQuerySchema.ts';
 import { languageParamsSchema } from '../_internal/request/languageParamsSchema.ts';
 import { limitlessQuerySchema } from '../_internal/request/limitlessQuerySchema.ts';
 import { linksQuerySchema } from '../_internal/request/linksQuerySchema.ts';
+import { mediaFilterParamsSchema } from '../_internal/request/mediaFilterParamsSchema.ts';
 import { pageQuerySchema } from '../_internal/request/pageQuerySchema.ts';
 import { periodParamsSchema } from '../_internal/request/periodParamsSchema.ts';
 import { recentPeriodParamsSchema } from '../_internal/request/recentPeriodParamsSchema.ts';
 import { statsQuerySchema } from '../_internal/request/statsQuerySchema.ts';
-import { streamingParamsSchema } from '../_internal/request/streamingParamsSchema.ts';
 import { commentResponseSchema } from '../_internal/response/commentResponseSchema.ts';
 import { episodeResponseSchema } from '../_internal/response/episodeResponseSchema.ts';
 import { episodeStatsResponseSchema } from '../_internal/response/episodeStatsResponseSchema.ts';
@@ -309,6 +309,7 @@ const GLOBAL_LEVEL = builder.router({
     path: '/trending',
     method: 'GET',
     query: extendedQuerySchemaFactory<['full', 'images', 'colors']>()
+      .merge(mediaFilterParamsSchema)
       .merge(pageQuerySchema)
       .merge(ignoreQuerySchema),
     responses: {
@@ -319,6 +320,7 @@ const GLOBAL_LEVEL = builder.router({
     path: '/watched/:period',
     method: 'GET',
     query: extendedQuerySchemaFactory<['full', 'images', 'colors']>()
+      .merge(mediaFilterParamsSchema)
       .merge(pageQuerySchema)
       .merge(ignoreQuerySchema),
     pathParams: periodParamsSchema,
@@ -330,6 +332,7 @@ const GLOBAL_LEVEL = builder.router({
     path: '/anticipated',
     method: 'GET',
     query: extendedQuerySchemaFactory<['full', 'images', 'colors']>()
+      .merge(mediaFilterParamsSchema)
       .merge(pageQuerySchema)
       .merge(ignoreQuerySchema),
     responses: {
@@ -340,6 +343,7 @@ const GLOBAL_LEVEL = builder.router({
     path: '/popular',
     method: 'GET',
     query: extendedQuerySchemaFactory<['full', 'images', 'colors']>()
+      .merge(mediaFilterParamsSchema)
       .merge(pageQuerySchema)
       .merge(ignoreQuerySchema),
     responses: {
@@ -351,7 +355,7 @@ const GLOBAL_LEVEL = builder.router({
     method: 'GET',
     pathParams: recentPeriodParamsSchema,
     query: extendedQuerySchemaFactory<['full', 'images', 'colors']>()
-      .merge(streamingParamsSchema)
+      .merge(mediaFilterParamsSchema)
       .merge(pageQuerySchema)
       .merge(ignoreQuerySchema),
     responses: {

--- a/projects/api/src/contracts/users/subroutes/userLists.ts
+++ b/projects/api/src/contracts/users/subroutes/userLists.ts
@@ -2,6 +2,7 @@ import { builder } from '../../_internal/builder.ts';
 import { extendedQuerySchemaFactory } from '../../_internal/request/extendedQuerySchemaFactory.ts';
 import { limitlessQuerySchema } from '../../_internal/request/limitlessQuerySchema.ts';
 import { listRequestSchema } from '../../_internal/request/listRequestSchema.ts';
+import { mediaFilterParamsSchema } from '../../_internal/request/mediaFilterParamsSchema.ts';
 import { pageQuerySchema } from '../../_internal/request/pageQuerySchema.ts';
 import { sortQuerySchema } from '../../_internal/request/sortQuerySchema.ts';
 import { commentResponseSchema } from '../../_internal/response/commentResponseSchema.ts';
@@ -35,6 +36,8 @@ const list = builder.router({
     method: 'GET',
     pathParams: profileParamsSchema
       .merge(listParamsSchema)
+      /** NOTE: technically not supported yet */
+      .merge(mediaFilterParamsSchema)
       .merge(
         searchTypeParamFactory<
           ['movie', 'show']

--- a/projects/api/src/contracts/users/subroutes/watchlist.ts
+++ b/projects/api/src/contracts/users/subroutes/watchlist.ts
@@ -1,5 +1,6 @@
 import { builder } from '../../_internal/builder.ts';
 import { extendedQuerySchemaFactory } from '../../_internal/request/extendedQuerySchemaFactory.ts';
+import { mediaFilterParamsSchema } from '../../_internal/request/mediaFilterParamsSchema.ts';
 import { pageQuerySchema } from '../../_internal/request/pageQuerySchema.ts';
 import { commentResponseSchema } from '../../_internal/response/commentResponseSchema.ts';
 import { listedMovieResponseSchema } from '../../_internal/response/listedMovieResponseSchema.ts';
@@ -14,7 +15,9 @@ export const watchlist = builder.router({
     pathParams: profileParamsSchema.merge(sortParamsSchema),
     method: 'GET',
     query: extendedQuerySchemaFactory<['full', 'images']>()
-      .merge(pageQuerySchema),
+      .merge(pageQuerySchema)
+      /** NOTE: technically not supported yet */
+      .merge(mediaFilterParamsSchema),
     responses: {
       200: listedMovieResponseSchema.array(),
     },
@@ -24,7 +27,9 @@ export const watchlist = builder.router({
     pathParams: profileParamsSchema.merge(sortParamsSchema),
     method: 'GET',
     query: extendedQuerySchemaFactory<['full', 'images']>()
-      .merge(pageQuerySchema),
+      .merge(pageQuerySchema)
+      /** NOTE: technically not supported yet */
+      .merge(mediaFilterParamsSchema),
     responses: {
       200: listedShowResponseSchema.array(),
     },


### PR DESCRIPTION
This pull request introduces a new `mediaFilterParamsSchema` to standardize media filtering parameters and integrates it across multiple API endpoints. The changes include the creation of the schema, its replacement of the deprecated `streamingParamsSchema`, and its addition to various query schemas for lists, movies, shows, recommendations, and user-specific endpoints.

### Schema Creation and Replacement:
* Added a new `mediaFilterParamsSchema` in `projects/api/src/contracts/_internal/request/mediaFilterParamsSchema.ts` to define filtering options like `watchnow`, `genres`, `years`, and `ratings`. This replaces the deprecated `streamingParamsSchema`. (`[[1]](diffhunk://#diff-a6c5449084da821397629940dfaff3db62f94ea8dbf166e5247a9630d3c7d02eR1-R8)`, `[[2]](diffhunk://#diff-3d1033df5e3cc1b7d37fb52db11bf1caf353fa75c1b5f56170caab42bc5897ddL1-L5)`)

### Integration into API Endpoints:
#### Lists:
* Integrated `mediaFilterParamsSchema` into the query schemas for list endpoints, including `ENTITY_LEVEL` and `GLOBAL_LEVEL` routes. (`[[1]](diffhunk://#diff-907ec597d112503890558625653622b47fd0fb030d2cdb50b7c8e1d041087c2cL19-R22)`, `[[2]](diffhunk://#diff-907ec597d112503890558625653622b47fd0fb030d2cdb50b7c8e1d041087c2cR37-R38)`, `[[3]](diffhunk://#diff-907ec597d112503890558625653622b47fd0fb030d2cdb50b7c8e1d041087c2cL76-R83)`, `[[4]](diffhunk://#diff-907ec597d112503890558625653622b47fd0fb030d2cdb50b7c8e1d041087c2cL85-R94)`)

#### Movies and Shows:
* Replaced `streamingParamsSchema` with `mediaFilterParamsSchema` in movie and show endpoints, and added it to various `GLOBAL_LEVEL` routes like `/trending`, `/anticipated`, and `/popular`. (`[[1]](diffhunk://#diff-181ea4191a699af2ca7acd72ca848efc9f23268923cc7500302fe91ba05dec46R9-L12)`, `[[2]](diffhunk://#diff-181ea4191a699af2ca7acd72ca848efc9f23268923cc7500302fe91ba05dec46R170)`, `[[3]](diffhunk://#diff-181ea4191a699af2ca7acd72ca848efc9f23268923cc7500302fe91ba05dec46L212-R215)`, `[[4]](diffhunk://#diff-4b28829c03a747436bb3bc5d5109bc8a56c982f2b171400cc8c397644268eb0aR9-L13)`, `[[5]](diffhunk://#diff-4b28829c03a747436bb3bc5d5109bc8a56c982f2b171400cc8c397644268eb0aL354-R358)`)

#### Recommendations:
* Enhanced the recommendations query schema by merging it with `mediaFilterParamsSchema` for both movies and shows. (`[[1]](diffhunk://#diff-64633d2c5a79c561148bdfa957528b3328cbff3a7007b81351e6023c669c7d7aR3)`, `[[2]](diffhunk://#diff-64633d2c5a79c561148bdfa957528b3328cbff3a7007b81351e6023c669c7d7aL34-R37)`)

#### User-Specific Endpoints:
* Added `mediaFilterParamsSchema` to user endpoints such as `userLists` and `watchlist` for improved filtering capabilities. (`[[1]](diffhunk://#diff-911129cd5755355a147f3c5b85cb8e54a00afb2ce751b64e95bbf679b6b964afR5)`, `[[2]](diffhunk://#diff-911129cd5755355a147f3c5b85cb8e54a00afb2ce751b64e95bbf679b6b964afR39-R40)`, `[[3]](diffhunk://#diff-2eb6e68ebe4042786b5cd90f01d3ccf0c8599e89dd7f4c8cc1d60050e5bf8d98L17-R20)`, `[[4]](diffhunk://#diff-2eb6e68ebe4042786b5cd90f01d3ccf0c8599e89dd7f4c8cc1d60050e5bf8d98L27-R32)`)