### PR TITLE
Enhances OpenAPI schema with custom Zod extensions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 
 # macOS
 .DS_Store
+
+openapi.json

--- a/projects/api/deno.json
+++ b/projects/api/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@trakt/api",
   "exports": "./src/index.ts",
-  "version": "0.1.41",
+  "version": "0.1.42",
   "imports": {
     "@anatine/zod-openapi": "npm:@anatine/zod-openapi@^2.2.6",
     "@std/testing": "jsr:@std/testing@^1.0.5",

--- a/projects/api/src/contracts/_internal/response/crewPositionResponseSchema.ts
+++ b/projects/api/src/contracts/_internal/response/crewPositionResponseSchema.ts
@@ -15,4 +15,4 @@ export const crewPositionResponseSchema = z.enum([
   'editing',
   'creator',
   'created by',
-]);
+]).forceString();

--- a/projects/api/src/contracts/_internal/response/crewPositionResponseSchema.ts
+++ b/projects/api/src/contracts/_internal/response/crewPositionResponseSchema.ts
@@ -1,6 +1,6 @@
-import { z } from '../z.ts';
+import { asString, z } from '../z.ts';
 
-export const crewPositionResponseSchema = z.enum([
+export const crewPositionResponseSchema = asString(z.enum([
   'acting',
   'production',
   'art',
@@ -15,4 +15,4 @@ export const crewPositionResponseSchema = z.enum([
   'editing',
   'creator',
   'created by',
-]).forceString();
+]));

--- a/projects/api/src/contracts/_internal/response/distributionResponseSchema.ts
+++ b/projects/api/src/contracts/_internal/response/distributionResponseSchema.ts
@@ -1,44 +1,14 @@
 import { z } from '../z.ts';
 
 export const distributionResponseSchema = z.object({
-  1: z.number().openapi({
-    type: 'number',
-    format: 'float',
-  }),
-  2: z.number().openapi({
-    type: 'number',
-    format: 'float',
-  }),
-  3: z.number().openapi({
-    type: 'number',
-    format: 'float',
-  }),
-  4: z.number().openapi({
-    type: 'number',
-    format: 'float',
-  }),
-  5: z.number().openapi({
-    type: 'number',
-    format: 'float',
-  }),
-  6: z.number().openapi({
-    type: 'number',
-    format: 'float',
-  }),
-  7: z.number().openapi({
-    type: 'number',
-    format: 'float',
-  }),
-  8: z.number().openapi({
-    type: 'number',
-    format: 'float',
-  }),
-  9: z.number().openapi({
-    type: 'number',
-    format: 'float',
-  }),
-  10: z.number().openapi({
-    type: 'number',
-    format: 'float',
-  }),
+  1: z.number().float(),
+  2: z.number().float(),
+  3: z.number().float(),
+  4: z.number().float(),
+  5: z.number().float(),
+  6: z.number().float(),
+  7: z.number().float(),
+  8: z.number().float(),
+  9: z.number().float(),
+  10: z.number().float(),
 });

--- a/projects/api/src/contracts/_internal/response/distributionResponseSchema.ts
+++ b/projects/api/src/contracts/_internal/response/distributionResponseSchema.ts
@@ -1,14 +1,14 @@
-import { z } from '../z.ts';
+import { float, z } from '../z.ts';
 
 export const distributionResponseSchema = z.object({
-  1: z.number().float(),
-  2: z.number().float(),
-  3: z.number().float(),
-  4: z.number().float(),
-  5: z.number().float(),
-  6: z.number().float(),
-  7: z.number().float(),
-  8: z.number().float(),
-  9: z.number().float(),
-  10: z.number().float(),
+  1: float(z.number()),
+  2: float(z.number()),
+  3: float(z.number()),
+  4: float(z.number()),
+  5: float(z.number()),
+  6: float(z.number()),
+  7: float(z.number()),
+  8: float(z.number()),
+  9: float(z.number()),
+  10: float(z.number()),
 });

--- a/projects/api/src/contracts/_internal/response/episodeResponseSchema.ts
+++ b/projects/api/src/contracts/_internal/response/episodeResponseSchema.ts
@@ -1,4 +1,4 @@
-import { z } from '../z.ts';
+import { float, z } from '../z.ts';
 import { episodeIdsResponseSchema } from './episodeIdsResponseSchema.ts';
 
 export const episodeResponseSchema = z.object({
@@ -10,7 +10,7 @@ export const episodeResponseSchema = z.object({
   /***
    * Available if requesting extended `full`.
    */
-  rating: z.number().float().optional(),
+  rating: float(z.number()).optional(),
   /***
    * Available if requesting extended `full`.
    */

--- a/projects/api/src/contracts/_internal/response/episodeResponseSchema.ts
+++ b/projects/api/src/contracts/_internal/response/episodeResponseSchema.ts
@@ -10,11 +10,7 @@ export const episodeResponseSchema = z.object({
   /***
    * Available if requesting extended `full`.
    */
-  rating: z.number()
-    .openapi({
-      type: 'number',
-      format: 'float',
-    }).optional(),
+  rating: z.number().float().optional(),
   /***
    * Available if requesting extended `full`.
    */

--- a/projects/api/src/contracts/_internal/response/genreEnumSchema.ts
+++ b/projects/api/src/contracts/_internal/response/genreEnumSchema.ts
@@ -1,6 +1,6 @@
-import { z } from '../z.ts';
+import { asString, z } from '../z.ts';
 
-export const genreEnumSchema = z.enum([
+export const genreEnumSchema = asString(z.enum([
   'action',
   'adventure',
   'animation',
@@ -38,4 +38,4 @@ export const genreEnumSchema = z.enum([
   'anime',
   'superhero',
   'donghua',
-]).forceString();
+]));

--- a/projects/api/src/contracts/_internal/response/genreEnumSchema.ts
+++ b/projects/api/src/contracts/_internal/response/genreEnumSchema.ts
@@ -38,4 +38,4 @@ export const genreEnumSchema = z.enum([
   'anime',
   'superhero',
   'donghua',
-]);
+]).forceString();

--- a/projects/api/src/contracts/_internal/response/jobResponseSchema.ts
+++ b/projects/api/src/contracts/_internal/response/jobResponseSchema.ts
@@ -133,4 +133,4 @@ export const jobResponseSchema = z.enum([
   'Writer',
   "Writers' Assistant",
   "Writers' Production",
-]);
+]).forceString();

--- a/projects/api/src/contracts/_internal/response/jobResponseSchema.ts
+++ b/projects/api/src/contracts/_internal/response/jobResponseSchema.ts
@@ -1,7 +1,7 @@
-import { z } from '../z.ts';
+import { asString, z } from '../z.ts';
 
 // TODO split up in separate schemas
-export const jobResponseSchema = z.enum([
+export const jobResponseSchema = asString(z.enum([
   /*
     Temporary list to type mock responses.
     TODO @seferturan: update this list with all job titles.
@@ -133,4 +133,4 @@ export const jobResponseSchema = z.enum([
   'Writer',
   "Writers' Assistant",
   "Writers' Production",
-]).forceString();
+]));

--- a/projects/api/src/contracts/_internal/response/movieCertificationResponseSchema.ts
+++ b/projects/api/src/contracts/_internal/response/movieCertificationResponseSchema.ts
@@ -15,4 +15,4 @@ export const movieCertificationResponseSchema = z.enum([
   'Unrated',
   'X',
   'Young',
-]);
+]).forceString();

--- a/projects/api/src/contracts/_internal/response/movieCertificationResponseSchema.ts
+++ b/projects/api/src/contracts/_internal/response/movieCertificationResponseSchema.ts
@@ -1,6 +1,6 @@
-import { z } from '../z.ts';
+import { asString, z } from '../z.ts';
 
-export const movieCertificationResponseSchema = z.enum([
+export const movieCertificationResponseSchema = asString(z.enum([
   // In the data, there are entries with the value 'undefined'
   'undefined',
 
@@ -15,4 +15,4 @@ export const movieCertificationResponseSchema = z.enum([
   'Unrated',
   'X',
   'Young',
-]).forceString();
+]));

--- a/projects/api/src/contracts/_internal/response/movieResponseSchema.ts
+++ b/projects/api/src/contracts/_internal/response/movieResponseSchema.ts
@@ -42,11 +42,7 @@ export const movieResponseSchema = z.object({
   /***
    * Available if requesting extended `full`.
    */
-  rating: z.number()
-    .openapi({
-      type: 'number',
-      format: 'float',
-    }).optional(),
+  rating: z.number().float().optional(),
   /***
    * Available if requesting extended `full`.
    */

--- a/projects/api/src/contracts/_internal/response/movieResponseSchema.ts
+++ b/projects/api/src/contracts/_internal/response/movieResponseSchema.ts
@@ -1,4 +1,4 @@
-import { z } from '../z.ts';
+import { float, z } from '../z.ts';
 import { genreEnumSchema } from './genreEnumSchema.ts';
 import { imagesResponseSchema } from './imagesResponseSchema.ts';
 import { mediaColorsResponseSchema } from './mediaColorsResponseSchema.ts';
@@ -42,7 +42,7 @@ export const movieResponseSchema = z.object({
   /***
    * Available if requesting extended `full`.
    */
-  rating: z.number().float().optional(),
+  rating: float(z.number()).optional(),
   /***
    * Available if requesting extended `full`.
    */

--- a/projects/api/src/contracts/_internal/response/ratingsResponseSchema.ts
+++ b/projects/api/src/contracts/_internal/response/ratingsResponseSchema.ts
@@ -1,14 +1,14 @@
-import { z } from '../z.ts';
+import { float, z } from '../z.ts';
 import { distributionResponseSchema } from './distributionResponseSchema.ts';
 
 const externalRatingsResponseSchema = z.object({
-  rating: z.number().float().nullable(),
+  rating: float(z.number()).nullable(),
   link: z.string().nullable(),
 });
 
 export const ratingsResponseSchema = z.object({
   trakt: z.object({
-    rating: z.number().float(),
+    rating: float(z.number()),
     votes: z.number().int(),
     distribution: distributionResponseSchema,
   }),

--- a/projects/api/src/contracts/_internal/response/ratingsResponseSchema.ts
+++ b/projects/api/src/contracts/_internal/response/ratingsResponseSchema.ts
@@ -2,19 +2,13 @@ import { z } from '../z.ts';
 import { distributionResponseSchema } from './distributionResponseSchema.ts';
 
 const externalRatingsResponseSchema = z.object({
-  rating: z.number().openapi({
-    type: 'number',
-    format: 'float',
-  }).nullable(),
+  rating: z.number().float().nullable(),
   link: z.string().nullable(),
 });
 
 export const ratingsResponseSchema = z.object({
   trakt: z.object({
-    rating: z.number().openapi({
-      type: 'number',
-      format: 'float',
-    }),
+    rating: z.number().float(),
     votes: z.number().int(),
     distribution: distributionResponseSchema,
   }),

--- a/projects/api/src/contracts/_internal/response/showCertificationResponseSchema.ts
+++ b/projects/api/src/contracts/_internal/response/showCertificationResponseSchema.ts
@@ -13,4 +13,4 @@ export const showCertificationResponseSchema = z.enum([
   'NC-17',
   'R',
   'PG',
-]);
+]).forceString();

--- a/projects/api/src/contracts/_internal/response/showCertificationResponseSchema.ts
+++ b/projects/api/src/contracts/_internal/response/showCertificationResponseSchema.ts
@@ -1,6 +1,6 @@
-import { z } from '../z.ts';
+import { asString, z } from '../z.ts';
 
-export const showCertificationResponseSchema = z.enum([
+export const showCertificationResponseSchema = asString(z.enum([
   'TV-14',
   'TV-Y7',
   'TV-Y',
@@ -13,4 +13,4 @@ export const showCertificationResponseSchema = z.enum([
   'NC-17',
   'R',
   'PG',
-]).forceString();
+]));

--- a/projects/api/src/contracts/_internal/response/showResponseSchema.ts
+++ b/projects/api/src/contracts/_internal/response/showResponseSchema.ts
@@ -1,4 +1,4 @@
-import { z } from '../z.ts';
+import { float, z } from '../z.ts';
 import { genreEnumSchema } from './genreEnumSchema.ts';
 import { imagesResponseSchema } from './imagesResponseSchema.ts';
 import { mediaColorsResponseSchema } from './mediaColorsResponseSchema.ts';
@@ -61,7 +61,7 @@ export const showResponseSchema = z.object({
   /**
    * Available if requesting extended `full`.
    */
-  rating: z.number().float().optional(),
+  rating: float(z.number()).optional(),
   /**
    * Available if requesting extended `full`.
    */

--- a/projects/api/src/contracts/_internal/response/showResponseSchema.ts
+++ b/projects/api/src/contracts/_internal/response/showResponseSchema.ts
@@ -61,11 +61,7 @@ export const showResponseSchema = z.object({
   /**
    * Available if requesting extended `full`.
    */
-  rating: z.number()
-    .openapi({
-      type: 'number',
-      format: 'float',
-    }).optional(),
+  rating: z.number().float().optional(),
   /**
    * Available if requesting extended `full`.
    */

--- a/projects/api/src/contracts/_internal/response/statusResponseSchema.ts
+++ b/projects/api/src/contracts/_internal/response/statusResponseSchema.ts
@@ -12,4 +12,4 @@ export const statusResponseSchema = z.enum([
   'pilot',
   'continuing',
   'upcoming',
-]);
+]).forceString();

--- a/projects/api/src/contracts/_internal/response/statusResponseSchema.ts
+++ b/projects/api/src/contracts/_internal/response/statusResponseSchema.ts
@@ -1,6 +1,6 @@
-import { z } from '../z.ts';
+import { asString, z } from '../z.ts';
 
-export const statusResponseSchema = z.enum([
+export const statusResponseSchema = asString(z.enum([
   'released',
   'planned',
   'post production',
@@ -12,4 +12,4 @@ export const statusResponseSchema = z.enum([
   'pilot',
   'continuing',
   'upcoming',
-]).forceString();
+]));

--- a/projects/api/src/contracts/_internal/response/videoResponseSchema.ts
+++ b/projects/api/src/contracts/_internal/response/videoResponseSchema.ts
@@ -1,10 +1,10 @@
-import { z } from 'zod';
+import { asString, z } from '../z.ts';
 
 export const videoResponseSchema = z.object({
   title: z.string(),
   url: z.string(),
   site: z.string(),
-  type: z.enum([
+  type: asString(z.enum([
     'trailer',
     'clip',
     'teaser',
@@ -12,7 +12,7 @@ export const videoResponseSchema = z.object({
     'recap',
     'behind the scenes',
     'opening credits',
-  ]).forceString(),
+  ])),
   size: z.number().int(),
   official: z.boolean(),
   published_at: z.string().datetime(),

--- a/projects/api/src/contracts/_internal/response/videoResponseSchema.ts
+++ b/projects/api/src/contracts/_internal/response/videoResponseSchema.ts
@@ -12,7 +12,7 @@ export const videoResponseSchema = z.object({
     'recap',
     'behind the scenes',
     'opening credits',
-  ]),
+  ]).forceString(),
   size: z.number().int(),
   official: z.boolean(),
   published_at: z.string().datetime(),

--- a/projects/api/src/contracts/_internal/z.ts
+++ b/projects/api/src/contracts/_internal/z.ts
@@ -14,6 +14,10 @@ declare module 'zod' {
      */
     float(): this;
 
+    /**
+     * Marks a ZodType as a string in OpenAPI metadata.
+     */
+    forceString(): this;
   }
 }
 
@@ -33,6 +37,22 @@ Object.defineProperty(z.ZodType.prototype, 'float', {
     return this.openapi({
       type: 'number',
       format: 'float',
+    });
+  },
+  writable: true,
+  configurable: true,
+  enumerable: false,
+});
+
+/**
+ * Extends ZodType with an forceString() method that adds OpenAPI metadata
+ * for documenting enum fields as strings.
+ */
+Object.defineProperty(z.ZodType.prototype, 'forceString', {
+  value() {
+    return this.openapi({
+      type: 'string',
+      enum: undefined,
     });
   },
   writable: true,

--- a/projects/api/src/contracts/_internal/z.ts
+++ b/projects/api/src/contracts/_internal/z.ts
@@ -1,9 +1,43 @@
 import { extendZodWithOpenApi } from '@anatine/zod-openapi';
-import { z } from 'zod';
+import { z, type ZodTypeDef } from 'zod';
+
+declare module 'zod' {
+  // skipcq: JS-0323, JS-0356
+  // deno-lint-ignore no-explicit-any
+  interface ZodSchema<Output = any, Def extends ZodTypeDef = ZodTypeDef, Input = Output> {
+    /**
+     * Marks a number as a float in OpenAPI metadata.
+     * This doesn't change the runtime validation behavior,
+     * but adds OpenAPI metadata for documentation and client generation.
+     * 
+     * @returns The same ZodType instance with OpenAPI metadata
+     */
+    float(): this;
+
+  }
+}
+
 
 /**
  * TODO: https://ts-rest.com/docs/open-api
  * extend with open-api metadata
  */
 extendZodWithOpenApi(z);
+
+/**
+ * Extends ZodType with a float() method that adds OpenAPI metadata
+ * for documenting number fields as floating point values.
+ */
+Object.defineProperty(z.ZodType.prototype, 'float', {
+  value() {
+    return this.openapi({
+      type: 'number',
+      format: 'float',
+    });
+  },
+  writable: true,
+  configurable: true,
+  enumerable: false,
+});
+
 export { z };

--- a/projects/api/src/contracts/_internal/z.ts
+++ b/projects/api/src/contracts/_internal/z.ts
@@ -1,63 +1,31 @@
 import { extendZodWithOpenApi } from '@anatine/zod-openapi';
-import { z, type ZodTypeDef } from 'zod';
+import { z } from 'zod';
 
-declare module 'zod' {
-  // skipcq: JS-0323, JS-0356
-  // deno-lint-ignore no-explicit-any
-  interface ZodSchema<Output = any, Def extends ZodTypeDef = ZodTypeDef, Input = Output> {
-    /**
-     * Marks a number as a float in OpenAPI metadata.
-     * This doesn't change the runtime validation behavior,
-     * but adds OpenAPI metadata for documentation and client generation.
-     * 
-     * @returns The same ZodType instance with OpenAPI metadata
-     */
-    float(): this;
-
-    /**
-     * Marks a ZodType as a string in OpenAPI metadata.
-     */
-    forceString(): this;
-  }
-}
-
-
-/**
- * TODO: https://ts-rest.com/docs/open-api
- * extend with open-api metadata
- */
+// Extend zod with the OpenAPI capabilities
 extendZodWithOpenApi(z);
 
 /**
- * Extends ZodType with a float() method that adds OpenAPI metadata
- * for documenting number fields as floating point values.
+ * Helper function to mark a number schema as a float in OpenAPI metadata
  */
-Object.defineProperty(z.ZodType.prototype, 'float', {
-  value() {
-    return this.openapi({
+export function float(schema: z.ZodNumber) {
+  // Use type assertion to access the openapi method added by extendZodWithOpenApi
+  return (schema as z.ZodNumber & { openapi: (meta: unknown) => z.ZodNumber })
+    .openapi({
       type: 'number',
       format: 'float',
     });
-  },
-  writable: true,
-  configurable: true,
-  enumerable: false,
-});
+}
 
 /**
- * Extends ZodType with an forceString() method that adds OpenAPI metadata
- * for documenting enum fields as strings.
+ * Helper function to force a schema to be treated as a string in OpenAPI metadata
  */
-Object.defineProperty(z.ZodType.prototype, 'forceString', {
-  value() {
-    return this.openapi({
+export function asString<T extends z.ZodEnum<[string, ...string[]]>>(schema: T) {
+  // Use type assertion to access the openapi method
+  return (schema as T & { openapi: (meta: unknown) => T })
+    .openapi({
       type: 'string',
       enum: undefined,
     });
-  },
-  writable: true,
-  configurable: true,
-  enumerable: false,
-});
+}
 
 export { z };

--- a/projects/api/src/contracts/certifications/_internal/movieCertificationsResponseSchema.ts
+++ b/projects/api/src/contracts/certifications/_internal/movieCertificationsResponseSchema.ts
@@ -6,7 +6,7 @@ const movieCertificationSlugResponseSchema = z.enum([
   'pg-13',
   'r',
   'nr',
-]);
+]).forceString();
 
 const certificationResponseSchema = z.object({
   name: z.string(),

--- a/projects/api/src/contracts/certifications/_internal/movieCertificationsResponseSchema.ts
+++ b/projects/api/src/contracts/certifications/_internal/movieCertificationsResponseSchema.ts
@@ -1,12 +1,12 @@
-import { z } from '../../_internal/z.ts';
+import { asString, z } from '../../_internal/z.ts';
 
-const movieCertificationSlugResponseSchema = z.enum([
+const movieCertificationSlugResponseSchema = asString(z.enum([
   'g',
   'pg',
   'pg-13',
   'r',
   'nr',
-]).forceString();
+]));
 
 const certificationResponseSchema = z.object({
   name: z.string(),

--- a/projects/api/src/contracts/certifications/_internal/showCertificationsResponseSchema.ts
+++ b/projects/api/src/contracts/certifications/_internal/showCertificationsResponseSchema.ts
@@ -8,7 +8,7 @@ const showCertificationSlugResponseSchema = z.enum([
   'tv-14',
   'tv-ma',
   'nr',
-]);
+]).forceString();
 
 const certificationResponseSchema = z.object({
   name: z.string(),

--- a/projects/api/src/contracts/certifications/_internal/showCertificationsResponseSchema.ts
+++ b/projects/api/src/contracts/certifications/_internal/showCertificationsResponseSchema.ts
@@ -1,6 +1,6 @@
-import { z } from '../../_internal/z.ts';
+import { asString, z } from '../../_internal/z.ts';
 
-const showCertificationSlugResponseSchema = z.enum([
+const showCertificationSlugResponseSchema = asString(z.enum([
   'tv-y',
   'tv-y7',
   'tv-g',
@@ -8,7 +8,7 @@ const showCertificationSlugResponseSchema = z.enum([
   'tv-14',
   'tv-ma',
   'nr',
-]).forceString();
+]));
 
 const certificationResponseSchema = z.object({
   name: z.string(),

--- a/projects/api/src/contracts/people/_internal/response/peopleSummaryResponseSchema.ts
+++ b/projects/api/src/contracts/people/_internal/response/peopleSummaryResponseSchema.ts
@@ -42,7 +42,7 @@ export const peopleSummaryResponseSchema = z.object({
   /***
    * Available if requesting extended `full`.
    */
-  gender: z.enum(['male', 'female', 'non_binary']).nullish(),
+  gender: z.enum(['male', 'female', 'non_binary']).forceString().nullish(),
   /***
    * Available if requesting extended `full`.
    */

--- a/projects/api/src/contracts/people/_internal/response/peopleSummaryResponseSchema.ts
+++ b/projects/api/src/contracts/people/_internal/response/peopleSummaryResponseSchema.ts
@@ -1,5 +1,5 @@
 import { crewPositionResponseSchema } from '../../../_internal/response/crewPositionResponseSchema.ts';
-import { z } from '../../../_internal/z.ts';
+import { asString, z } from '../../../_internal/z.ts';
 
 export const peopleSummaryResponseSchema = z.object({
   name: z.string(),
@@ -42,7 +42,7 @@ export const peopleSummaryResponseSchema = z.object({
   /***
    * Available if requesting extended `full`.
    */
-  gender: z.enum(['male', 'female', 'non_binary']).forceString().nullish(),
+  gender: asString(z.enum(['male', 'female', 'non_binary'])).nullish(),
   /***
    * Available if requesting extended `full`.
    */


### PR DESCRIPTION
Improves OpenAPI schema generation by introducing custom Zod extensions.

- Adds a `float()` extension to Zod's number type to explicitly mark numbers as floating-point values in the OpenAPI schema.
- Introduces a `forceString()` extension to Zod's enum type to ensure enums are represented as strings in the OpenAPI schema, improving compatibility and clarity.
- Refactors existing number schema definitions to use the new `float()` extension.
- Applies `forceString()` to relevant enum schemas.