### PR TITLE
fix: make non-trakt ids optional for movies

### DIFF
--- a/projects/api/src/contracts/_internal/response/movieIdsResponseSchema.ts
+++ b/projects/api/src/contracts/_internal/response/movieIdsResponseSchema.ts
@@ -4,8 +4,8 @@ import { streamingIdsResponseSchema } from './streamingIdsResponseSchema.ts';
 export const movieIdsResponseSchema = z.object({
   trakt: z.number().int(),
   slug: z.string(),
-  imdb: z.string(),
-  tmdb: z.number().int(),
+  imdb: z.string().nullable(),
+  tmdb: z.number().int().optional(),
   /**
    * Available if requesting extended `streaming_ids`.
    */


### PR DESCRIPTION
Similarly to shows this PR makes non-Trakt IDs optional.