### PR TITLE
Merges limitless and page query schemas

### DIFF
--- a/projects/api/src/contracts/_internal/request/limitlessQuerySchema.ts
+++ b/projects/api/src/contracts/_internal/request/limitlessQuerySchema.ts
@@ -1,5 +1,10 @@
 import { z } from '../z.ts';
 
 export const limitlessQuerySchema = z.object({
-  limit: z.literal('all').optional(),
+  limit: z.number()
+    .int()
+    .or(z.literal('all'))
+    .optional().openapi({
+      description: 'The number of items per page',
+    }),
 });

--- a/projects/api/src/contracts/lists/index.ts
+++ b/projects/api/src/contracts/lists/index.ts
@@ -36,7 +36,8 @@ const ENTITY_LEVEL = builder.router({
       ),
     query: extendedMediaQuerySchema
       .merge(mediaFilterParamsSchema)
-      .and(pageQuerySchema.or(limitlessQuerySchema)),
+      .merge(pageQuerySchema)
+      .merge(limitlessQuerySchema),
     responses: {
       200: z.union([listedMovieResponseSchema, listedShowResponseSchema])
         .array(),

--- a/projects/api/src/contracts/movies/index.ts
+++ b/projects/api/src/contracts/movies/index.ts
@@ -145,7 +145,8 @@ const ENTITY_LEVEL = builder.router({
     path: '/comments/:sort',
     method: 'GET',
     query: extendedProfileQuerySchema
-      .and(pageQuerySchema.or(limitlessQuerySchema)),
+      .merge(pageQuerySchema)
+      .merge(limitlessQuerySchema),
     pathParams: idParamsSchema.merge(commentsSortParamsSchema),
     responses: {
       200: commentResponseSchema.array(),

--- a/projects/api/src/contracts/shows/index.ts
+++ b/projects/api/src/contracts/shows/index.ts
@@ -105,7 +105,8 @@ const EPISODE_LEVEL = builder.router({
       .merge(episodeParamsSchema)
       .merge(commentsSortParamsSchema),
     query: extendedProfileQuerySchema
-      .and(pageQuerySchema.or(limitlessQuerySchema)),
+      .merge(pageQuerySchema)
+      .merge(limitlessQuerySchema),
     responses: {
       200: commentResponseSchema.array(),
     },

--- a/projects/api/src/contracts/users/index.ts
+++ b/projects/api/src/contracts/users/index.ts
@@ -51,7 +51,8 @@ const GLOBAL_LEVEL = builder.router({
       path: '/likes/comments',
       method: 'GET',
       query: extendedQuerySchemaFactory<['comments', 'min', 'full', 'images']>()
-        .and(pageQuerySchema.or(limitlessQuerySchema)),
+        .merge(pageQuerySchema)
+        .merge(limitlessQuerySchema),
       responses: {
         200: likedCommentResponseSchema.array(),
       },
@@ -60,7 +61,8 @@ const GLOBAL_LEVEL = builder.router({
       path: '/likes/lists',
       method: 'GET',
       query: extendedQuerySchemaFactory<['comments', 'min', 'full', 'images']>()
-        .and(pageQuerySchema.or(limitlessQuerySchema)),
+        .merge(pageQuerySchema)
+        .merge(limitlessQuerySchema),
       responses: {
         200: likedListResponseSchema.array(),
       },

--- a/projects/api/src/contracts/users/subroutes/userLists.ts
+++ b/projects/api/src/contracts/users/subroutes/userLists.ts
@@ -45,7 +45,8 @@ const list = builder.router({
     query: extendedMediaQuerySchema
       .merge(sortQuerySchema)
       .merge(mediaFilterParamsSchema)
-      .and(pageQuerySchema.or(limitlessQuerySchema)),
+      .merge(pageQuerySchema)
+      .merge(limitlessQuerySchema),
     responses: {
       200: z.union([listedMovieResponseSchema, listedShowResponseSchema])
         .array(),


### PR DESCRIPTION
Ensures that the `limitlessQuerySchema` and `pageQuerySchema` are properly merged in relevant API contracts.

- Previously, the schemas were being used with an `or` condition, which was not the intended behavior.
- This change updates the code to correctly merge the schemas, allowing both pagination and "limitless" queries to be used together.