### PR TITLE
Feat/month in review

### DIFF
--- a/projects/api/deno.json
+++ b/projects/api/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@trakt/api",
   "exports": "./src/index.ts",
-  "version": "0.1.42",
+  "version": "0.1.43",
   "imports": {
     "@anatine/zod-openapi": "npm:@anatine/zod-openapi@^2.2.6",
     "@std/testing": "jsr:@std/testing@^1.0.5",

--- a/projects/api/src/contracts/users/_internal/request/monthInReviewParamsSchema.ts
+++ b/projects/api/src/contracts/users/_internal/request/monthInReviewParamsSchema.ts
@@ -1,0 +1,6 @@
+import { z } from '../../../_internal/z.ts';
+
+export const monthInReviewParamsSchema = z.object({
+  year: z.number().int(),
+  month: z.number().int(),
+});

--- a/projects/api/src/contracts/users/_internal/response/monthInReviewResponseSchema.ts
+++ b/projects/api/src/contracts/users/_internal/response/monthInReviewResponseSchema.ts
@@ -1,0 +1,53 @@
+import { episodeResponseSchema } from '../../../_internal/response/episodeResponseSchema.ts';
+import { movieResponseSchema } from '../../../_internal/response/movieResponseSchema.ts';
+import { showResponseSchema } from '../../../_internal/response/showResponseSchema.ts';
+import { z } from '../../../_internal/z.ts';
+
+const statsSchema = z.object({
+  total: z.number(),
+  yearly: z.number(),
+  monthly: z.number(),
+  weekly: z.number(),
+  daily: z.number(),
+});
+
+const statsCategoriesSchema = z.object({
+  minutes: statsSchema,
+  play_counts: statsSchema,
+  collected_counts: statsSchema,
+  ratings_counts: statsSchema,
+  comments_counts: statsSchema,
+  lists_counts: statsSchema,
+});
+
+const watchedEpisodeSchema = z.object({
+  type: z.literal('episode'),
+  watched_at: z.string().datetime(),
+  episode: episodeResponseSchema,
+  show: showResponseSchema,
+});
+
+const watchedMovieSchema = z.object({
+  type: z.literal('movie'),
+  watched_at: z.string().datetime(),
+  movie: movieResponseSchema,
+});
+
+const watchedItemSchema = z.discriminatedUnion('type', [
+  watchedEpisodeSchema,
+  watchedMovieSchema,
+]);
+
+export const monthInReviewResponseSchema = z.object({
+  stats: z.object({
+    all: statsCategoriesSchema,
+    shows: statsCategoriesSchema,
+    movies: statsCategoriesSchema,
+  }),
+  images: z.object({
+    cover: z.string(),
+    story: z.string(),
+  }),
+  first_watched: watchedItemSchema,
+  last_watched: watchedItemSchema,
+});

--- a/projects/api/src/contracts/users/index.ts
+++ b/projects/api/src/contracts/users/index.ts
@@ -10,6 +10,7 @@ import { avatarRequestSchema } from './_internal/request/avatarRequestSchema.ts'
 import { commentOnTypeParamsSchema } from './_internal/request/commentOnTypeParamsSchema.ts';
 import { commentsRequestSchema } from './_internal/request/commentsRequestSchema.ts';
 import { commentTypeParamsSchema } from './_internal/request/commentTypeParamsSchema.ts';
+import { monthInReviewParamsSchema } from './_internal/request/monthInReviewParamsSchema.ts';
 import { profileParamsSchema } from './_internal/request/profileParamsSchema.ts';
 import { settingsRequestSchema } from './_internal/request/settingsRequestSchema.ts';
 import { socialActivityParamsSchema } from './_internal/request/socialActivityParamsSchema.ts';
@@ -21,6 +22,7 @@ import {
   likedCommentResponseSchema,
   likedListResponseSchema,
 } from './_internal/response/likedItemResponseSchema.ts';
+import { monthInReviewResponseSchema } from './_internal/response/monthInReviewResponseSchema.ts';
 import { settingsResponseSchema } from './_internal/response/settingsResponseSchema.ts';
 import { socialActivityResponseSchema } from './_internal/response/socialActivityResponseSchema.ts';
 import { userCommentResponseSchema } from './_internal/response/userCommentResponseSchema.ts';
@@ -183,6 +185,16 @@ const ENTITY_LEVEL = builder.router({
       200: friendResponseSchema.array(),
     },
   },
+  month_in_review: {
+    path: '/mir',
+    pathParams: profileParamsSchema
+      .merge(monthInReviewParamsSchema),
+    query: extendedMediaQuerySchema,
+    method: 'GET',
+    responses: {
+      200: monthInReviewResponseSchema,
+    },
+  },
 }, {
   pathPrefix: '/:id',
 });
@@ -245,3 +257,6 @@ export type UserCommentResponse = z.infer<typeof userCommentResponseSchema>;
 export type WatchingResponse = z.infer<typeof watchingResponseSchema>;
 export type AvatarRequest = z.infer<typeof avatarRequestSchema>;
 export type SettingsRequest = z.infer<typeof settingsRequestSchema>;
+
+export type MonthInReviewParams = z.infer<typeof monthInReviewParamsSchema>;
+export type MonthInReviewResponse = z.infer<typeof monthInReviewResponseSchema>;


### PR DESCRIPTION
## 🎶 Notes 🎶

- Adds support for getting month in review stats.
- Bumps version to 0.1.43

## 👀 Examples 👀

<img width="1144" alt="Screenshot 2025-06-04 at 15 10 22" src="https://github.com/user-attachments/assets/dcd1ac05-84f6-467c-afe9-29c27bc5b72d" />

<img width="1144" alt="Screenshot 2025-06-04 at 15 10 29" src="https://github.com/user-attachments/assets/3f8ae5b2-593b-42e1-8462-8bee92bacd12" />

Since the default images are pre-rendered widget-like images, you can request with `extended=images` to get the episode/show/movie images:
<img width="1144" alt="Screenshot 2025-06-04 at 15 01 35" src="https://github.com/user-attachments/assets/3a1775c9-4799-4ee6-933a-88b965f80349" />
