### PR TITLE
feat(watchnow): new schema for watch now filters

### DIFF
--- a/projects/api/src/contracts/_internal/request/mediaFilterParamsSchema.ts
+++ b/projects/api/src/contracts/_internal/request/mediaFilterParamsSchema.ts
@@ -1,7 +1,24 @@
 import { z } from '../z.ts';
 
 export const mediaFilterParamsSchema = z.object({
-  watchnow: z.enum(['favorites', 'any']).nullish(),
+  watchnow: z.enum([
+    'favorites',
+    'any',
+    'any_all',
+    'free',
+    'free_all',
+    'subscriptions',
+    'subscriptions_all',
+  ]).nullish().openapi({
+    description:
+      `Use "favorites" for streaming on a favorite service of the user.
+      Use "any" for streaming on any service in the user's country.
+      Use "any_all" for streaming on any service in all countries.
+      Use "free" for streaming for free in the user's country.
+      Use "free_all" for streaming for free in all countries.
+      Use "subscriptions" for streaming on any subscription service (Netflix, Hulu, etc) in the user's country.
+      Use "subscriptions_all" streaming on any subscription service in all countries`,
+  }),
   genres: z.string().nullish(),
   years: z.string().nullish(),
   ratings: z.string().nullish(),


### PR DESCRIPTION
## 🎶 Notes 🎶

- New schema for watchnow filtering
- I left `favorites` in there for now, it is a supported param on the server (in `user_streamable.rb`). We can leave it out on Lite until any issues regarding favorites are fixed.