### PR TITLE
feat / define hot endpoints

### DIFF
--- a/projects/api/src/contracts/movies/_internal/response/movieHotResponseSchema.ts
+++ b/projects/api/src/contracts/movies/_internal/response/movieHotResponseSchema.ts
@@ -1,0 +1,4 @@
+import { movieAnticipatedResponseSchema } from './movieAnticipatedResponseSchema.ts';
+
+export const movieHotResponseSchema = movieAnticipatedResponseSchema;
+// 

--- a/projects/api/src/contracts/movies/index.ts
+++ b/projects/api/src/contracts/movies/index.ts
@@ -37,6 +37,7 @@ import {
 } from '../_internal/response/watchNowResponseSchema.ts';
 import type { z } from '../_internal/z.ts';
 import { movieAnticipatedResponseSchema } from './_internal/response/movieAnticipatedResponseSchema.ts';
+import { movieHotResponseSchema } from './_internal/response/movieHotResponseSchema.ts';
 import { movieStreamingResponseSchema } from './_internal/response/movieStreamingResponseSchema.ts';
 import { movieTrendingResponseSchema } from './_internal/response/movieTrendingResponseSchema.ts';
 import { movieWatchedResponseSchema } from './_internal/response/movieWatchedResponseSchema.ts';
@@ -198,6 +199,17 @@ const GLOBAL_LEVEL = builder.router({
       200: movieAnticipatedResponseSchema.array(),
     },
   },
+  hot: {
+    path: '/hot',
+    method: 'GET',
+    query: extendedMediaQuerySchema
+      .merge(mediaFilterParamsSchema)
+      .merge(pageQuerySchema)
+      .merge(ignoreQuerySchema),
+    responses: {
+      200: movieHotResponseSchema.array(),
+    },
+  },
   popular: {
     path: '/popular',
     method: 'GET',
@@ -248,6 +260,9 @@ export type MovieWatchedResponse = z.infer<
 >;
 export type MovieAnticipatedResponse = z.infer<
   typeof movieAnticipatedResponseSchema
+>;
+export type MovieHotResponse = z.infer<
+  typeof movieHotResponseSchema
 >;
 export type MovieCertificationResponse = z.infer<
   typeof movieCertificationResponseSchema

--- a/projects/api/src/contracts/shows/_internal/response/showHotResponseSchema.ts
+++ b/projects/api/src/contracts/shows/_internal/response/showHotResponseSchema.ts
@@ -1,0 +1,7 @@
+import { showResponseSchema } from '../../../_internal/response/showResponseSchema.ts';
+import { z } from '../../../_internal/z.ts';
+
+export const showHotResponseSchema = z.object({
+  list_count: z.number().int(),
+  show: showResponseSchema,
+});

--- a/projects/api/src/contracts/shows/index.ts
+++ b/projects/api/src/contracts/shows/index.ts
@@ -37,6 +37,7 @@ import { seasonParamsSchema } from './_internal/request/seasonParamsSchema.ts';
 import { showQueryParamsSchema } from './_internal/request/showQueryParamsSchema.ts';
 import { seasonResponseSchema } from './_internal/response/seasonResponseSchema.ts';
 import { showAnticipatedResponseSchema } from './_internal/response/showAnticipatedResponseSchema.ts';
+import { showHotResponseSchema } from './_internal/response/showHotResponseSchema.ts';
 import { showProgressResponseSchema } from './_internal/response/showProgressResponseSchema.ts';
 import { showStreamingResponseSchema } from './_internal/response/showStreamingResponseSchema.ts';
 import { showTrendingResponseSchema } from './_internal/response/showTrendingResponseSchema.ts';
@@ -342,6 +343,17 @@ const GLOBAL_LEVEL = builder.router({
       200: showAnticipatedResponseSchema.array(),
     },
   },
+  hot: {
+    path: '/hot',
+    method: 'GET',
+    query: extendedMediaQuerySchema
+      .merge(mediaFilterParamsSchema)
+      .merge(pageQuerySchema)
+      .merge(ignoreQuerySchema),
+    responses: {
+      200: showHotResponseSchema.array(),
+    },
+  },
   popular: {
     path: '/popular',
     method: 'GET',
@@ -383,6 +395,9 @@ export type ShowWatchedResponse = z.infer<typeof showWatchedResponseSchema>;
 export type ShowStatsResponse = z.infer<typeof showStatsResponseSchema>;
 export type ShowAnticipatedResponse = z.infer<
   typeof showAnticipatedResponseSchema
+>;
+export type ShowHotResponse = z.infer<
+  typeof showHotResponseSchema
 >;
 
 export type ShowCertificationResponse = z.infer<


### PR DESCRIPTION
Adds new endpoints to retrieve a list of hot movies and shows.

- Defines the `movieHotResponseSchema` and `showHotResponseSchema` which reuse the `movieAnticipatedResponseSchema` and `showAnticipatedResponseSchema`.
- Registers the `/hot` route in both the movie and show routers with appropriate query parameters and response schemas.
- Exports the `MovieHotResponse` and `ShowHotResponse` types.