### PR TITLE
fix(user): change blocked_uids from unknown to number type

### DIFF
--- a/projects/api/src/contracts/users/_internal/response/settingsResponseSchema.ts
+++ b/projects/api/src/contracts/users/_internal/response/settingsResponseSchema.ts
@@ -110,7 +110,7 @@ export const settingsResponseSchema = z.object({
       favorites: z.array(genreEnumSchema).nullish(),
       disliked: z.array(genreEnumSchema).nullish(),
     }),
-    comments: z.object({ blocked_uids: z.array(z.unknown()) }),
+    comments: z.object({ blocked_uids: z.array(z.number().int()) }),
     recommendations: z.object({
       ignore_collected: z.boolean(),
       ignore_watchlisted: z.boolean(),


### PR DESCRIPTION
Not sure if there was any reason for this to be unknown that I don't know about.

Example response from a user:
```
    "comments": {
      "blocked_uids": [
        580779
      ]
    },
```