### PR TITLE
feat: adds support for extended movie/episode data

### DIFF
--- a/projects/api/deno.json
+++ b/projects/api/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@trakt/api",
   "exports": "./src/index.ts",
-  "version": "0.2.14",
+  "version": "0.2.15",
   "imports": {
     "@anatine/zod-openapi": "npm:@anatine/zod-openapi@^2.2.6",
     "@std/testing": "jsr:@std/testing@^1.0.5",

--- a/projects/api/src/contracts/_internal/response/episodeResponseSchema.ts
+++ b/projects/api/src/contracts/_internal/response/episodeResponseSchema.ts
@@ -51,13 +51,21 @@ export const episodeResponseSchema = z.object({
     .nullish(),
   ids: episodeIdsResponseSchema,
   /***
+   * Available if requesting extended `full`.
+   */
+  original_title: z.string().nullish(),
+  /***
+   * Available if requesting extended `full`.
+   */
+  after_credits: z.boolean().nullish(),
+  /***
+   * Available if requesting extended `full`.
+   */
+  during_credits: z.boolean().nullish(),
+  /***
    * Available if requesting extended `images`.
    */
   images: z
     .object({ screenshot: z.array(z.string()) })
     .nullish(),
-  /***
-   * Available if requesting extended `full`.
-   */
-  original_title: z.string().nullish(),
 });

--- a/projects/api/src/contracts/_internal/response/movieResponseSchema.ts
+++ b/projects/api/src/contracts/_internal/response/movieResponseSchema.ts
@@ -88,6 +88,14 @@ export const movieResponseSchema = z.object({
    */
   original_title: z.string().nullish(),
   /***
+   * Available if requesting extended `full`.
+   */
+  after_credits: z.boolean().nullish(),
+  /***
+   * Available if requesting extended `full`.
+   */
+  during_credits: z.boolean().nullish(),
+  /***
    * Available if requesting extended `colors`.
    */
   colors: mediaColorsResponseSchema.nullish(),


### PR DESCRIPTION
Adds support for `after_credits` and `during_credits` properties to movie and episode responses.

- These properties are available when requesting extended `full` data.
- Updates the package version to reflect these new features.