### PR TITLE
feat(search): updated search definitions for Kotlin client support

### DIFF
--- a/projects/api/src/contracts/search/_internal/request/searchEngineSchema.ts
+++ b/projects/api/src/contracts/search/_internal/request/searchEngineSchema.ts
@@ -1,0 +1,7 @@
+import { z } from '../../../_internal/z.ts';
+
+export const searchEngineSchema = z.object({
+  engine: z.string().nullish().openapi({
+    description: 'The search engine type to use.',
+  }),
+});

--- a/projects/api/src/contracts/search/_internal/response/searchMovieResponseSchema.ts
+++ b/projects/api/src/contracts/search/_internal/response/searchMovieResponseSchema.ts
@@ -1,6 +1,6 @@
 import { typedMovieResponseSchema } from '../../../_internal/response/movieResponseSchema.ts';
-import { z } from '../../../_internal/z.ts';
+import { int64, z } from '../../../_internal/z.ts';
 
 export const searchMovieResponseSchema = z.object({
-  score: z.number().int(),
+  score: int64(z.number().int()),
 }).merge(typedMovieResponseSchema);

--- a/projects/api/src/contracts/search/_internal/response/searchPersonResponseSchema.ts
+++ b/projects/api/src/contracts/search/_internal/response/searchPersonResponseSchema.ts
@@ -1,8 +1,8 @@
-import { z } from '../../../_internal/z.ts';
+import { int64, z } from '../../../_internal/z.ts';
 import { peopleSummaryResponseSchema } from '../../../people/_internal/response/peopleSummaryResponseSchema.ts';
 
 export const searchPersonResponseSchema = z.object({
-  score: z.number().int(),
+  score: int64(z.number().int()),
   type: z.literal('person'),
   person: peopleSummaryResponseSchema,
 });

--- a/projects/api/src/contracts/search/_internal/response/searchShowResponseSchema.ts
+++ b/projects/api/src/contracts/search/_internal/response/searchShowResponseSchema.ts
@@ -1,6 +1,6 @@
 import { typedShowResponseSchema } from '../../../_internal/response/showResponseSchema.ts';
-import { z } from '../../../_internal/z.ts';
+import { int64, z } from '../../../_internal/z.ts';
 
 export const searchShowResponseSchema = z.object({
-  score: z.number().int(),
+  score: int64(z.number().int()),
 }).merge(typedShowResponseSchema);

--- a/projects/api/src/contracts/search/index.ts
+++ b/projects/api/src/contracts/search/index.ts
@@ -5,6 +5,7 @@ import type { z } from '../_internal/z.ts';
 import { searchQuerySchema } from './_internal/request/searchQuerySchema.ts';
 import { searchTypeParamFactory } from './_internal/request/searchTypeParamFactory.ts';
 import { searchResultResponseSchema } from './_internal/response/searchResultResponseSchema.ts';
+import { searchEngineSchema } from "./_internal/request/searchEngineSchema.ts";
 
 /**
  * TODO: add support for 'episode', 'list'
@@ -18,6 +19,7 @@ export const search = builder.router({
       ['movie', 'show', 'person']
     >(),
     query: searchQuerySchema
+      .merge(searchEngineSchema)
       .merge(pageQuerySchema)
       .merge(
         extendedQuerySchemaFactory<['full,images']>(),


### PR DESCRIPTION
- score as Int64 (Long)
- nullish result options
- added engine parameter for request

Results in:

```kotlin
@Serializable
data class GetSearchQuery200ResponseInner (

    @SerialName(value = "score")
    val score: kotlin.Long,

    @SerialName(value = "type")
    val type: GetSearchQuery200ResponseInner.Type,

    @SerialName(value = "movie")
    val movie: GetUsersLikesComments200ResponseInnerAllOfOneOfMovie? = null,

    @SerialName(value = "show")
    val show: GetUsersLikesComments200ResponseInnerAllOfOneOf1Show? = null,

    @SerialName(value = "person")
    val person: GetSearchQuery200ResponseInnerOneOf2Person? = null

)
```