### PR TITLE
fix: make grant_type a string not literal

### DIFF
--- a/projects/api/src/contracts/oauth/_internal/request/tokenRefreshSchema.ts
+++ b/projects/api/src/contracts/oauth/_internal/request/tokenRefreshSchema.ts
@@ -6,5 +6,8 @@ export const tokenRefreshSchema = tokenBaseSchema.extend({
     description:
       'The refresh token which was sent from the server during the exchange of the code.',
   }),
-  grant_type: z.literal('refresh_token'),
+  grant_type: z.string({
+    description:
+      'Defines how an access token is obtained.',
+  }),
 });

--- a/projects/api/src/contracts/oauth/_internal/request/tokenRequestSchema.ts
+++ b/projects/api/src/contracts/oauth/_internal/request/tokenRequestSchema.ts
@@ -6,5 +6,8 @@ export const tokenRequestSchema = tokenBaseSchema.extend({
     description:
       'The code received when trakt redirects the user back to the application.',
   }),
-  grant_type: z.literal('authorization_code'),
+  grant_type: z.string({
+    description:
+      'Defines how an access token is obtained.',
+  }),
 });


### PR DESCRIPTION
Allows to keep .union() and make it compatible with Kotlin