### PR TITLE
fix: nullish watchActionSchema

### DIFF
--- a/projects/api/src/contracts/users/schema/response/settingsResponseSchema.ts
+++ b/projects/api/src/contracts/users/schema/response/settingsResponseSchema.ts
@@ -37,7 +37,7 @@ export const settingsResponseSchema = z.object({
    * Available if requesting extended `browsing`.
    */
   browsing: z.object({
-    watch_popup_action: watchActionSchema,
+    watch_popup_action: watchActionSchema.nullish(),
     hide_watching_now: z.boolean(),
     list_popup_action: z.string(),
     week_start_day: z.string().nullish(),


### PR DESCRIPTION
Fixes nullish field encountered by user.

```
Unexpected JSON token at offset 778: Expected string literal but ‘null’ literal was found
Path: $.browsing.watch_popup_action
```