### PR TITLE
fix: remove extra ? in /watchnow query

### DIFF
--- a/projects/api/src/contracts/_internal/request/countryParamsSchema.ts
+++ b/projects/api/src/contracts/_internal/request/countryParamsSchema.ts
@@ -1,7 +1,7 @@
 import { z } from '../z.ts';
 
 export const countryParamsSchema = z.object({
-  country: z.string().openapi({
+  country: z.string().optional().openapi({
     description: '2 character country code.',
   }),
 });

--- a/projects/api/src/contracts/episodes/index.ts
+++ b/projects/api/src/contracts/episodes/index.ts
@@ -5,7 +5,7 @@ import { watchNowResponseSchema } from '../_internal/response/watchNowResponseSc
 
 export const episodes = builder.router({
   watchnow: {
-    path: '/watchnow/:country?',
+    path: '/watchnow/:country',
     query: linksQuerySchema,
     method: 'GET',
     pathParams: watchNowParamsSchema,

--- a/projects/api/src/contracts/movies/index.ts
+++ b/projects/api/src/contracts/movies/index.ts
@@ -1,5 +1,6 @@
 import { builder } from '../_internal/builder.ts';
 import { commentsSortParamsSchema } from '../_internal/request/commentsSortParamsSchema.ts';
+import { countryParamsSchema } from '../_internal/request/countryParamsSchema.ts';
 import { extendedMediaQuerySchema } from '../_internal/request/extendedMediaQuerySchema.ts';
 import { extendedProfileQuerySchema } from '../_internal/request/extendedProfileQuerySchema.ts';
 import { extendedQuerySchemaFactory } from '../_internal/request/extendedQuerySchemaFactory.ts';
@@ -104,10 +105,10 @@ const ENTITY_LEVEL = builder.router({
     },
   },
   watchnow: {
-    path: '/watchnow/:country?',
+    path: '/watchnow/:country',
     query: linksQuerySchema,
     method: 'GET',
-    pathParams: idParamsSchema,
+    pathParams: idParamsSchema.merge(countryParamsSchema),
     responses: {
       200: watchNowResponseSchema,
     },

--- a/projects/api/src/contracts/shows/index.ts
+++ b/projects/api/src/contracts/shows/index.ts
@@ -1,5 +1,6 @@
 import { builder } from '../_internal/builder.ts';
 import { commentsSortParamsSchema } from '../_internal/request/commentsSortParamsSchema.ts';
+import { countryParamsSchema } from '../_internal/request/countryParamsSchema.ts';
 import { extendedMediaQuerySchema } from '../_internal/request/extendedMediaQuerySchema.ts';
 import { extendedProfileQuerySchema } from '../_internal/request/extendedProfileQuerySchema.ts';
 import { extendedQuerySchemaFactory } from '../_internal/request/extendedQuerySchemaFactory.ts';
@@ -125,10 +126,10 @@ const EPISODE_LEVEL = builder.router({
     },
   },
   watchnow: {
-    path: '/watchnow/:country?',
+    path: '/watchnow/:country',
     query: linksQuerySchema,
     method: 'GET',
-    pathParams: idParamsSchema
+    pathParams: idParamsSchema.merge(countryParamsSchema)
       .merge(seasonParamsSchema)
       .merge(episodeParamsSchema),
     responses: {
@@ -215,10 +216,10 @@ const ENTITY_LEVEL = builder.router({
     },
   },
   watchnow: {
-    path: '/watchnow/:country?',
+    path: '/watchnow/:country',
     query: linksQuerySchema,
     method: 'GET',
-    pathParams: idParamsSchema,
+    pathParams: idParamsSchema.merge(countryParamsSchema),
     responses: {
       200: watchNowResponseSchema,
     },


### PR DESCRIPTION
Removes extra ? that caused generating query as:

```
https://apiz.trakt.tv/shows/144629/watchnow/us??links=direct
```

which caused missing `link_direct` in responses.