### PR TITLE
fix: idOnlySchema made nullable

### DIFF
--- a/projects/api/src/contracts/comments/schema/requests/commentPostParamsSchema.ts
+++ b/projects/api/src/contracts/comments/schema/requests/commentPostParamsSchema.ts
@@ -5,7 +5,7 @@ const idOnlySchema = z.object({
   ids: z.object({
     trakt: z.number().int(),
   }),
-});
+}).nullish();
 
 export const commentPostParamsSchema = commentReplyParamsSchema.and(
   z.union([


### PR DESCRIPTION
This PR makes post comment request object media params nullish. Results in properly generated Request:

```kotlin
@Serializable
data class PostCommentsPostRequest (

    @SerialName(value = "comment")
    val comment: kotlin.String,

    @SerialName(value = "spoiler")
    val spoiler: kotlin.Boolean,

    @SerialName(value = "movie")
    val movie: PostCommentsPostRequestAllOfOneOfMovie? = null,

    @SerialName(value = "show")
    val show: PostCommentsPostRequestAllOfOneOfMovie? = null,

    @SerialName(value = "season")
    val season: PostCommentsPostRequestAllOfOneOfMovie? = null,

    @SerialName(value = "episode")
    val episode: PostCommentsPostRequestAllOfOneOfMovie? = null,

    @SerialName(value = "list")
    val list: PostCommentsPostRequestAllOfOneOfMovie? = null
)
```