### PR TITLE
fix: add missing possible option for watchActionSchema

### DIFF
--- a/projects/api/src/contracts/users/schema/response/watchActionSchema.ts
+++ b/projects/api/src/contracts/users/schema/response/watchActionSchema.ts
@@ -1,3 +1,3 @@
 import { z } from '../../../_internal/z.ts';
 
-export const watchActionSchema = z.enum(['now', 'ask', 'released']);
+export const watchActionSchema = z.enum(['now', 'ask', 'released', 'unknown']);


### PR DESCRIPTION
Adds "unknown" to watchActionSchema enum. Related to:

<img width="668" height="249" alt="image" src="https://github.com/user-attachments/assets/b22bb054-aed9-42ca-b0de-d5f9c62c39fc" />
