### PR TITLE
fix: nullish episode title

### DIFF
--- a/projects/api/src/contracts/_internal/response/episodeResponseSchema.ts
+++ b/projects/api/src/contracts/_internal/response/episodeResponseSchema.ts
@@ -5,7 +5,7 @@ import { showResponseSchema } from './showResponseSchema.ts';
 export const episodeResponseSchema = z.object({
   season: z.number().int(),
   number: z.number().int(),
-  title: z.string(),
+  title: z.string().nullish(),
   first_aired: z.string().nullish(),
   number_abs: z.number().int().nullish(),
   /***


### PR DESCRIPTION
It appears that episode model title can be returned as null.

Not 100% if this should be just a nullish fix as in this PR or anything deeper should be done (so that it's sure that title can never be returned null, just empty or some default like "Episode 12" instead)

