### PR TITLE
fix: remove added '?' for paths

### DIFF
--- a/projects/api/src/contracts/comments/index.ts
+++ b/projects/api/src/contracts/comments/index.ts
@@ -44,7 +44,7 @@ const REACTIONS_LEVEL = builder.router({
     },
   },
   remove: {
-    path: '/:reaction_type?',
+    path: '/:reaction_type',
     method: 'DELETE',
     pathParams: z.object({
       reaction_type: reactionEnumSchema.optional(),

--- a/projects/api/src/contracts/users/subroutes/watchlist.ts
+++ b/projects/api/src/contracts/users/subroutes/watchlist.ts
@@ -14,7 +14,7 @@ import { sortParamsSchema } from '../schema/request/sortParamsSchema.ts';
 
 export const watchlist = builder.router({
   movies: {
-    path: '/movies/:sort?',
+    path: '/movies/:sort',
     pathParams: profileParamsSchema
       .merge(sortParamsSchema.partial()),
     method: 'GET',
@@ -28,7 +28,7 @@ export const watchlist = builder.router({
     },
   },
   shows: {
-    path: '/shows/:sort?',
+    path: '/shows/:sort',
     pathParams: profileParamsSchema
       .merge(sortParamsSchema.partial()),
     method: 'GET',
@@ -42,7 +42,7 @@ export const watchlist = builder.router({
     },
   },
   all: {
-    path: '/movie,show/:sort?',
+    path: '/movie,show/:sort',
     pathParams: profileParamsSchema
       .merge(sortParamsSchema.partial()),
     method: 'GET',


### PR DESCRIPTION
This PR removes excessive ? in few paths which caused double "??" generation.