### PR TITLE
feat(oauth2): add support for oauth2 (all routes but /oauth)

### DIFF
--- a/projects/openapi/generate.ts
+++ b/projects/openapi/generate.ts
@@ -2,28 +2,60 @@ import { traktContract } from '@trakt/api';
 import { generateOpenApi } from './generateOpenApi.ts';
 
 export function generate(): ReturnType<typeof generateOpenApi> {
-  return generateOpenApi(traktContract, {
-    info: {
-      title: 'Trakt API',
-      version: '2.0.0',
+  return generateOpenApi(
+    traktContract,
+    {
+      info: {
+        title: 'Trakt API',
+        version: '2.0.0',
+      },
+      components: {
+        securitySchemes: {
+          traktOAuth: {
+            type: 'oauth2',
+            flows: {
+              authorizationCode: {
+                authorizationUrl: 'https://api.trakt.tv/oauth/authorize',
+                tokenUrl: 'https://api.trakt.tv/oauth/token',
+                scopes: {
+                  public: 'Access public data',
+                },
+              },
+            },
+          },
+        },
+      },
     },
-  }, {
-    operationMapper: (operation, route, id) => {
-      const parts = [
-        ...(operation.tags ?? []),
-        id,
-      ];
+    {
+      operationMapper: (operation, route, id) => {
+        const parts = [
+          ...(operation.tags ?? []),
+          id,
+        ];
 
-      return {
-        ...operation,
-        operationId: `${route.method.toLowerCase()}${
-          parts
-            .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
-            .join('')
-        }`,
-      };
+        const isOAuthRoute = (operation.tags ?? []).includes('oauth');
+
+        const security = isOAuthRoute
+          ? []
+          : [
+            {
+              traktOAuth: [],
+            },
+            {},
+          ];
+
+        return {
+          ...operation,
+          security,
+          operationId: `${route.method.toLowerCase()}${
+            parts
+              .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+              .join('')
+          }`,
+        };
+      },
     },
-  });
+  );
 }
 
 if (import.meta.main) {


### PR DESCRIPTION
Here's my AI assisted attempt at adding support for OAuth2 to the OpenAPI spec. It should add the required securitySchemes components and updates the security param for each routes except the ones starting with /oauth.

This is needed to support the "try" feature of the readme documentation.