### PR TITLE
feat: Adds social IDs to movie and show responses

### DIFF
--- a/projects/api/deno.json
+++ b/projects/api/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@trakt/api",
   "exports": "./src/index.ts",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "imports": {
     "@anatine/zod-openapi": "npm:@anatine/zod-openapi@^2.2.6",
     "@std/testing": "jsr:@std/testing@^1.0.5",

--- a/projects/api/src/contracts/_internal/response/movieResponseSchema.ts
+++ b/projects/api/src/contracts/_internal/response/movieResponseSchema.ts
@@ -4,6 +4,7 @@ import { imagesResponseSchema } from './imagesResponseSchema.ts';
 import { mediaColorsResponseSchema } from './mediaColorsResponseSchema.ts';
 import { movieCertificationResponseSchema } from './movieCertificationResponseSchema.ts';
 import { movieIdsResponseSchema } from './movieIdsResponseSchema.ts';
+import { socialIdsResponseSchema } from './socialIdsResponseSchema.ts';
 import { statusResponseSchema } from './statusResponseSchema.ts';
 
 export const movieResponseSchema = z.object({
@@ -103,6 +104,10 @@ export const movieResponseSchema = z.object({
    * Available if requesting extended `colors`.
    */
   colors: mediaColorsResponseSchema.nullish(),
+  /***
+   * Available if requesting extended `full`.
+   */
+  social_ids: socialIdsResponseSchema.nullish(),
 });
 
 export const typedMovieResponseSchema = z.object({

--- a/projects/api/src/contracts/_internal/response/showResponseSchema.ts
+++ b/projects/api/src/contracts/_internal/response/showResponseSchema.ts
@@ -4,6 +4,7 @@ import { imagesResponseSchema } from './imagesResponseSchema.ts';
 import { mediaColorsResponseSchema } from './mediaColorsResponseSchema.ts';
 import { showCertificationResponseSchema } from './showCertificationResponseSchema.ts';
 import { showIdsResponseSchema } from './showIdsResponseSchema.ts';
+import { socialIdsResponseSchema } from './socialIdsResponseSchema.ts';
 import { statusResponseSchema } from './statusResponseSchema.ts';
 
 export const showResponseSchema = z.object({
@@ -114,6 +115,10 @@ export const showResponseSchema = z.object({
    * Available if requesting extended `colors`.
    */
   colors: mediaColorsResponseSchema.nullish(),
+  /***
+   * Available if requesting extended `full`.
+   */
+  social_ids: socialIdsResponseSchema.nullish(),
 });
 
 export const typedShowResponseSchema = z.object({

--- a/projects/api/src/contracts/_internal/response/socialIdsResponseSchema.ts
+++ b/projects/api/src/contracts/_internal/response/socialIdsResponseSchema.ts
@@ -1,0 +1,8 @@
+import { z } from '../z.ts';
+
+export const socialIdsResponseSchema = z.object({
+  twitter: z.string().nullish(),
+  facebook: z.string().nullish(),
+  instagram: z.string().nullish(),
+  wikipedia: z.string().nullish(),
+});

--- a/projects/api/src/contracts/models/index.ts
+++ b/projects/api/src/contracts/models/index.ts
@@ -20,6 +20,7 @@ import {
 import { profileResponseSchema } from '../_internal/response/profileResponseSchema.ts';
 import { ratingsResponseSchema } from '../_internal/response/ratingsResponseSchema.ts';
 import { sentimentsResponseSchema } from '../_internal/response/sentimentsResponseSchema.ts';
+import { socialIdsResponseSchema } from '../_internal/response/socialIdsResponseSchema.ts';
 import { statusResponseSchema } from '../_internal/response/statusResponseSchema.ts';
 import { studioResponseSchema } from '../_internal/response/studioResponseSchema.ts';
 import { translationResponseSchema } from '../_internal/response/translationResponseSchema.ts';
@@ -111,3 +112,8 @@ export type JustWatchLinkResponse = z.infer<typeof justWatchLinkResponseSchema>;
 
 export { videoResponseSchema };
 export type VideoResponse = z.infer<typeof videoResponseSchema>;
+
+export { socialIdsResponseSchema };
+export type SocialIdsResponse = z.infer<
+  typeof socialIdsResponseSchema
+>;

--- a/projects/api/src/contracts/people/schema/response/personResponseSchema.ts
+++ b/projects/api/src/contracts/people/schema/response/personResponseSchema.ts
@@ -1,4 +1,5 @@
 import { crewPositionResponseSchema } from '../../../_internal/response/crewPositionResponseSchema.ts';
+import { socialIdsResponseSchema } from '../../../_internal/response/socialIdsResponseSchema.ts';
 import { asString, z } from '../../../_internal/z.ts';
 
 export const personResponseSchema = z.object({
@@ -13,12 +14,7 @@ export const personResponseSchema = z.object({
   /***
    * Available if requesting extended `full`.
    */
-  social_ids: z.object({
-    twitter: z.string().nullish(),
-    facebook: z.string().nullish(),
-    instagram: z.string().nullish(),
-    wikipedia: z.string().nullish(),
-  }).nullish(),
+  social_ids: socialIdsResponseSchema.nullish(),
   /***
    * Available if requesting extended `full`.
    */


### PR DESCRIPTION
## 🎶 Notes 🎶

- Introduces a shared `social_ids` response schema to standardize social media identifiers.
- Extends the movie and show response schemas with a new `social_ids` field, available when requesting the `full` extended data.
- Refactors the existing `social_ids` field within the person response schema to utilize the newly created shared schema for consistency.
- Bumps the API package version to 0.4.4.