### PR TITLE
Adds new progress and user hidden endpoints

### DIFF
--- a/projects/api/deno.json
+++ b/projects/api/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@trakt/api",
   "exports": "./src/index.ts",
-  "version": "0.4.6",
+  "version": "0.4.7",
   "imports": {
     "@anatine/zod-openapi": "npm:@anatine/zod-openapi@^2.2.6",
     "@std/testing": "jsr:@std/testing@^1.0.5",

--- a/projects/api/src/contracts/sync/index.ts
+++ b/projects/api/src/contracts/sync/index.ts
@@ -79,6 +79,20 @@ const progress = builder.router({
       },
     },
   },
+  watched: {
+    method: 'GET',
+    path: '/progress/watched',
+    query: extendedQuerySchemaFactory<['full', 'images']>()
+      .merge(pageQuerySchema)
+      .merge(sortQuerySchema)
+      .merge(z.object({
+        hide_completed: z.boolean().optional(),
+        hide_not_completed: z.boolean().optional(),
+      })),
+    responses: {
+      200: upNextResponseSchema.array(),
+    },
+  },
 });
 
 const history = builder.router({

--- a/projects/api/src/contracts/sync/schema/request/upNextIntentQuerySchema.ts
+++ b/projects/api/src/contracts/sync/schema/request/upNextIntentQuerySchema.ts
@@ -1,8 +1,8 @@
 import { z } from '../../../_internal/z.ts';
 
 export const upNextIntentQuerySchema = z.object({
-  intent: z.enum(['all', 'continue', 'start']).optional().openapi({
+  intent: z.enum(['all', 'continue', 'start', 'completed']).optional().openapi({
     description:
-      'To get shows a user is just starting, continuing, or all shows.',
+      'To get shows a user is just starting, continuing, completed, or all shows.',
   }),
 });

--- a/projects/api/src/contracts/users/subroutes/hidden.ts
+++ b/projects/api/src/contracts/users/subroutes/hidden.ts
@@ -29,6 +29,13 @@ export const hidden = builder.router({
       200: hiddenShowResponseSchema.array(),
     },
   },
+  dropped: {
+    path: '/dropped',
+    method: 'GET',
+    query: extendedQuerySchemaFactory<['full', 'images']>()
+      .merge(pageQuerySchema),
+    responses: { 200: hiddenShowResponseSchema.array() },
+  },
   remove: {
     progress: {
       path: '/progress_watched/remove',


### PR DESCRIPTION
## 🎶 Notes 🎶
- Adds a new GET endpoint `/sync/progress/watched` to retrieve a user's watched content progress, including options to filter by completion status.
- Extends the `upNextIntentQuerySchema` to include a 'completed' intent, allowing for more granular filtering of up next shows.
- Implements a new GET endpoint `/users/hidden/dropped` for fetching content a user has marked as dropped.
- Bumps the API version to `0.4.7`.