### PR TITLE
Refines API and Sync Contract Schemas

### DIFF
--- a/projects/api/src/contracts/_internal/response/showStatsResponseSchema.ts
+++ b/projects/api/src/contracts/_internal/response/showStatsResponseSchema.ts
@@ -1,6 +1,3 @@
-import { z } from '../z.ts';
 import { movieStatsResponseSchema } from './movieStatsResponseSchema.ts';
 
-export const showStatsResponseSchema = movieStatsResponseSchema.extend({
-  collected_episodes: z.number().int(),
-});
+export const showStatsResponseSchema = movieStatsResponseSchema;

--- a/projects/api/src/contracts/sync/schema/response/collectionMinimalResponseSchema.ts
+++ b/projects/api/src/contracts/sync/schema/response/collectionMinimalResponseSchema.ts
@@ -7,5 +7,8 @@ export const collectionMinimalResponseSchema = z.record(
 
 export const collectionMinimalShowResponseSchema = z.record(
   z.string(),
-  collectionMinimalResponseSchema,
+  z.record(
+    z.string(),
+    collectionMinimalResponseSchema,
+  ),
 );

--- a/projects/api/src/contracts/sync/schema/response/movieProgressResponseSchema.ts
+++ b/projects/api/src/contracts/sync/schema/response/movieProgressResponseSchema.ts
@@ -1,9 +1,9 @@
 import { z } from 'zod';
-import { int64 } from '../../../_internal/z.ts';
+import { float, int64 } from '../../../_internal/z.ts';
 import { movieResponseSchema } from '../../../movies/index.ts';
 
 export const movieProgressResponseSchema = z.object({
-  progress: z.number().min(0).max(100),
+  progress: float(z.number().min(0).max(100)),
   paused_at: z.string().datetime(),
   id: int64(z.number().int()),
   type: z.literal('movie'),


### PR DESCRIPTION
## 🎶 Notes 🎶
- Corrects the schema for minimal collection shows to properly represent a nested record structure.
- Removes the `collected_episodes` field from the show statistics response schema, aligning it with `movieStatsResponseSchema`.
- Updates the movie progress response schema to accurately use a float type for progress values.