### PR TITLE
Adds user block and unblock functionality

### DIFF
--- a/projects/api/src/contracts/users/index.ts
+++ b/projects/api/src/contracts/users/index.ts
@@ -18,6 +18,7 @@ import { settingsRequestSchema } from './schema/request/settingsRequestSchema.ts
 import { socialActivityParamsSchema } from './schema/request/socialActivityParamsSchema.ts';
 import { sortEnumSchema } from './schema/request/sortParamsSchema.ts';
 import { yearInReviewParamsSchema } from './schema/request/yearInReviewParamsSchema.ts';
+import { blockedUserResponseSchema } from './schema/response/blockedUserResponseSchema.ts';
 import { followerResponseSchema } from './schema/response/followerResponseSchema.ts';
 import { followResponseSchema } from './schema/response/followResponseSchema.ts';
 import { friendResponseSchema } from './schema/response/friendResponseSchema.ts';
@@ -111,6 +112,13 @@ const GLOBAL_LEVEL = builder.router({
     body: settingsRequestSchema,
     responses: {
       201: z.undefined(),
+    },
+  },
+  blocked: {
+    path: '/blocked',
+    method: 'GET',
+    responses: {
+      200: blockedUserResponseSchema.array(),
     },
   },
 });
@@ -281,6 +289,7 @@ export type * from './subroutes/watchlist.ts';
 
 export {
   avatarRequestSchema,
+  blockedUserResponseSchema,
   commentOnTypeParamsSchema,
   commentsRequestSchema,
   commentTypeParamsSchema,
@@ -324,6 +333,7 @@ export type FollowerResponse = z.infer<
   typeof followerResponseSchema
 >;
 export type FollowResponse = z.infer<typeof followResponseSchema>;
+export type BlockedUserResponse = z.infer<typeof blockedUserResponseSchema>;
 export type FriendResponse = z.infer<typeof friendResponseSchema>;
 
 export type UserStatsResponse = z.infer<typeof userStatsResponseSchema>;

--- a/projects/api/src/contracts/users/index.ts
+++ b/projects/api/src/contracts/users/index.ts
@@ -184,6 +184,24 @@ const ENTITY_LEVEL = builder.router({
       204: z.undefined(),
     },
   },
+  block: {
+    path: '/block',
+    method: 'POST',
+    pathParams: profileParamsSchema,
+    body: z.undefined(),
+    responses: {
+      201: z.undefined(),
+      409: z.undefined(),
+    },
+  },
+  unblock: {
+    path: '/block',
+    method: 'DELETE',
+    pathParams: profileParamsSchema,
+    responses: {
+      204: z.undefined(),
+    },
+  },
   followers: {
     path: '/followers',
     method: 'GET',

--- a/projects/api/src/contracts/users/schema/response/blockedUserResponseSchema.ts
+++ b/projects/api/src/contracts/users/schema/response/blockedUserResponseSchema.ts
@@ -1,0 +1,7 @@
+import { profileResponseSchema } from '../../../_internal/response/profileResponseSchema.ts';
+import { z } from '../../../_internal/z.ts';
+
+export const blockedUserResponseSchema = z.object({
+  blocked_at: z.string().datetime(),
+  user: profileResponseSchema,
+});


### PR DESCRIPTION
## Description

This pull request introduces new API endpoints for managing user blocking and unblocking within the contracts. This feature empowers users with the ability to control their interactions on the platform by allowing them to block specific profiles to prevent unwanted communication or content. Conversely, it also provides the mechanism to unblock a user, restoring normal interaction capabilities. The `POST /block` endpoint handles the blocking action, while the `DELETE /block` endpoint facilitates the unblocking process, both utilizing existing profile parameters to identify the target user.