### PR TITLE
fix(api): add API key auth and required headers to generated OpenAPI …

### DIFF
--- a/projects/openapi/generate.ts
+++ b/projects/openapi/generate.ts
@@ -61,8 +61,18 @@ export function generate(): ReturnType<typeof generateOpenApi> {
         version: '2.0.0',
       },
       servers,
+      security: [
+        {
+          traktAPI: [],
+        },
+      ],
       components: {
         securitySchemes: {
+          traktAPI: {
+            type: 'apiKey',
+            in: 'header',
+            name: 'trakt-api-key',
+          },
           traktOAuth: {
             type: 'oauth2',
             flows: {
@@ -76,6 +86,18 @@ export function generate(): ReturnType<typeof generateOpenApi> {
             },
           },
         },
+      },
+      'x-readme': {
+        headers: [
+          {
+            key: 'User-Agent',
+            value: 'readme/1.0',
+          },
+          {
+            key: 'trakt-api-version',
+            value: '2',
+          },
+        ],
       },
     },
     {


### PR DESCRIPTION
## Summary

Adds the Trakt API key (and other required) header details to the generated OpenAPI document.

- adds `traktAPI` under `components.securitySchemes`
- applies `traktAPI` as document-level security
- adds ReadMe static headers for `User-Agent` and `trakt-api-version`
- preserves operation-level OAuth security from route auth metadata