### PR TITLE
feat(users): Adds minimal watched shows endpoint

### DIFF
--- a/projects/api/deno.json
+++ b/projects/api/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@trakt/api",
   "exports": "./src/index.ts",
-  "version": "0.4.9",
+  "version": "0.4.10",
   "imports": {
     "@anatine/zod-openapi": "npm:@anatine/zod-openapi@^2.2.6",
     "@std/testing": "jsr:@std/testing@^1.0.5",

--- a/projects/api/src/contracts/users/schema/response/watchedShowsMinimalResponseSchema.ts
+++ b/projects/api/src/contracts/users/schema/response/watchedShowsMinimalResponseSchema.ts
@@ -1,0 +1,12 @@
+import { z } from '../../../_internal/z.ts';
+
+export const watchedShowsMinimalResponseSchema = z.record(
+  z.string(),
+  z.record(
+    z.string(),
+    z.record(
+      z.string(),
+      z.string().datetime().array(),
+    ),
+  ),
+);

--- a/projects/api/src/contracts/users/subroutes/watched.ts
+++ b/projects/api/src/contracts/users/subroutes/watched.ts
@@ -1,11 +1,12 @@
 import { builder } from '../../_internal/builder.ts';
 import { extendedQuerySchemaFactory } from '../../_internal/request/extendedQuerySchemaFactory.ts';
-import type { z } from '../../_internal/z.ts';
+import { z } from '../../_internal/z.ts';
 import { showQueryParamsSchema } from '../../shows/schema/request/showQueryParamsSchema.ts';
 import { minimalParamSchema } from '../../sync/schema/request/minimalParamSchema.ts';
 import { profileParamsSchema } from '../schema/request/profileParamsSchema.ts';
 import { watchedMoviesMinimalResponseSchema } from '../schema/response/watchedMoviesMinimalResponseSchema.ts';
 import { watchedMoviesResponseSchema } from '../schema/response/watchedMoviesResponseSchema.ts';
+import { watchedShowsMinimalResponseSchema } from '../schema/response/watchedShowsMinimalResponseSchema.ts';
 import { watchedShowsResponseSchema } from '../schema/response/watchedShowsResponseSchema.ts';
 
 export const watched = builder.router({
@@ -37,6 +38,19 @@ export const watched = builder.router({
         200: watchedMoviesMinimalResponseSchema,
       },
     },
+    shows: {
+      path: '/shows',
+      method: 'GET',
+      pathParams: profileParamsSchema,
+      query: minimalParamSchema.merge(
+        showQueryParamsSchema.pick({ specials: true }),
+      ).extend({
+        season_numbers: z.boolean().nullish(),
+      }),
+      responses: {
+        200: watchedShowsMinimalResponseSchema,
+      },
+    },
   }),
 }, {
   pathPrefix: '/:id/watched',
@@ -47,4 +61,8 @@ export type WatchedShowsResponse = z.infer<typeof watchedShowsResponseSchema>;
 
 export type WatchedMoviesMinimalResponse = z.infer<
   typeof watchedMoviesMinimalResponseSchema
+>;
+
+export type WatchedShowsMinimalResponse = z.infer<
+  typeof watchedShowsMinimalResponseSchema
 >;


### PR DESCRIPTION
## 🎶 Notes 🎶

- Introduces a new API endpoint (`GET /users/:id/watched/shows`) to retrieve a user's watched shows in a minimal, summarized format.
- Defines a new Zod schema (`watchedShowsMinimalResponseSchema`) to represent the structure of this minimal response.
- Bumps the API project version to `0.4.10`.
