### PR TITLE
fix(users): add show context to episode comment response

### DIFF
--- a/projects/api/deno.json
+++ b/projects/api/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@trakt/api",
   "exports": "./src/index.ts",
-  "version": "0.4.10",
+  "version": "0.4.11",
   "imports": {
     "@anatine/zod-openapi": "npm:@anatine/zod-openapi@^2.2.6",
     "@std/testing": "jsr:@std/testing@^1.0.5",

--- a/projects/api/src/contracts/users/schema/response/userCommentResponseSchema.ts
+++ b/projects/api/src/contracts/users/schema/response/userCommentResponseSchema.ts
@@ -1,7 +1,10 @@
 import { commentResponseSchema } from '../../../_internal/response/commentResponseSchema.ts';
 import { episodeResponseSchema } from '../../../_internal/response/episodeResponseSchema.ts';
 import { typedMovieResponseSchema } from '../../../_internal/response/movieResponseSchema.ts';
-import { typedShowResponseSchema } from '../../../_internal/response/showResponseSchema.ts';
+import {
+  showResponseSchema,
+  typedShowResponseSchema,
+} from '../../../_internal/response/showResponseSchema.ts';
 import { z } from '../../../_internal/z.ts';
 import { seasonResponseSchema } from '../../../shows/schema/response/seasonResponseSchema.ts';
 
@@ -22,6 +25,7 @@ const commentedSeasonResponseSchema = z.object({
 const commentedEpisodeResponseSchema = z.object({
   type: z.literal('episode'),
   episode: episodeResponseSchema,
+  show: showResponseSchema,
   comment: commentResponseSchema,
 });
 


### PR DESCRIPTION
## 🎶 Notes 🎶
- Enhances the `userCommentResponseSchema` for episodes to include the full `show` object. This ensures that when an episode comment is retrieved, the response provides complete context by including details of the show to which the episode belongs.
- Updates the API version to `0.4.11`.
