### PR TITLE
feat(sync): document lifetime_stats and only_rewatching on progress endpoint

### DIFF
--- a/projects/api/src/contracts/_internal/request/lifetimeStatsQuerySchema.ts
+++ b/projects/api/src/contracts/_internal/request/lifetimeStatsQuerySchema.ts
@@ -1,0 +1,8 @@
+import { z } from '../z.ts';
+
+export const lifetimeStatsQuerySchema = z.object({
+  lifetime_stats: z.boolean().optional().openapi({
+    description:
+      'When true, `progress.completed` and `progress.stats` reflect lifetime totals across all watches of the show. When false (default), they reflect the current watching session — i.e. counters reset by `/shows/:id/progress/watched/reset`.',
+  }),
+});

--- a/projects/api/src/contracts/sync/index.ts
+++ b/projects/api/src/contracts/sync/index.ts
@@ -1,6 +1,7 @@
 import { authMetadata, builder } from '../_internal/builder.ts';
 import { bulkMediaRequestSchema } from '../_internal/request/bulkMediaRequestSchema.ts';
 import { extendedQuerySchemaFactory } from '../_internal/request/extendedQuerySchemaFactory.ts';
+import { lifetimeStatsQuerySchema } from '../_internal/request/lifetimeStatsQuerySchema.ts';
 import { listRequestSchema } from '../_internal/request/listRequestSchema.ts';
 import { pageQuerySchema } from '../_internal/request/pageQuerySchema.ts';
 import { sortQuerySchema } from '../_internal/request/sortQuerySchema.ts';
@@ -44,7 +45,8 @@ const progress = builder.router({
       query: extendedQuerySchemaFactory<['full', 'images']>()
         .merge(pageQuerySchema)
         .merge(sortQuerySchema)
-        .merge(statsQuerySchema),
+        .merge(statsQuerySchema)
+        .merge(lifetimeStatsQuerySchema),
       responses: {
         200: upNextResponseSchema.array(),
       },
@@ -85,9 +87,14 @@ const progress = builder.router({
     query: extendedQuerySchemaFactory<['full', 'images']>()
       .merge(pageQuerySchema)
       .merge(sortQuerySchema)
+      .merge(lifetimeStatsQuerySchema)
       .merge(z.object({
         hide_completed: z.boolean().optional(),
         hide_not_completed: z.boolean().optional(),
+        only_rewatching: z.boolean().optional().openapi({
+          description:
+            'When true, restrict the list to shows the user is currently rewatching (i.e. those with an active `progress.reset_at`).',
+        }),
       })),
     responses: {
       200: upNextResponseSchema.array(),


### PR DESCRIPTION

Add `lifetime_stats` query param to `/sync/progress/up_next` and `/sync/progress/watched`, and `only_rewatching` to `/sync/progress/watched`. `only_rewatching` now acts purely as a filter; lifetime-vs-current-session stats behavior moves to the dedicated `lifetime_stats` flag.

Following https://github.com/trakt/trakt-workers/pull/691