### PR TITLE
feat(users): adds all ratings endpoint and pagination

### DIFF
--- a/projects/api/deno.json
+++ b/projects/api/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@trakt/api",
   "exports": "./src/index.ts",
-  "version": "0.4.11",
+  "version": "0.4.12",
   "imports": {
     "@anatine/zod-openapi": "npm:@anatine/zod-openapi@^2.2.6",
     "@std/testing": "jsr:@std/testing@^1.0.5",

--- a/projects/api/src/contracts/scrobble/index.ts
+++ b/projects/api/src/contracts/scrobble/index.ts
@@ -1,5 +1,4 @@
 import { authMetadata, builder } from '../_internal/builder.ts';
-import { extendedQuerySchemaFactory } from '../_internal/request/extendedQuerySchemaFactory.ts';
 import { z } from '../_internal/z.ts';
 import { episodeScrobbleRequestSchema } from './schema/request/episodeScrobbleRequestSchema.ts';
 import { movieScrobbleRequestSchema } from './schema/request/movieScrobbleRequestSchema.ts';
@@ -24,7 +23,10 @@ Use this method when the video initially starts playing or is unpaused. This wil
     method: 'POST',
     body: z.union([movieScrobbleRequestSchema, episodeScrobbleRequestSchema]),
     responses: {
-      201: z.union([movieScrobbleResponseSchema, episodeScrobbleResponseSchema]),
+      201: z.union([
+        movieScrobbleResponseSchema,
+        episodeScrobbleResponseSchema,
+      ]),
     },
   },
   pause: {
@@ -35,7 +37,10 @@ Pause an active scrobble for a movie or episode. Send the media object and curre
     method: 'POST',
     body: z.union([movieScrobbleRequestSchema, episodeScrobbleRequestSchema]),
     responses: {
-      201: z.union([movieScrobbleResponseSchema, episodeScrobbleResponseSchema]),
+      201: z.union([
+        movieScrobbleResponseSchema,
+        episodeScrobbleResponseSchema,
+      ]),
     },
   },
   stop: {
@@ -60,7 +65,10 @@ If the progress is between 1% and 79%, it will be treated as a *pause* and the \
     method: 'POST',
     body: z.union([movieScrobbleRequestSchema, episodeScrobbleRequestSchema]),
     responses: {
-      201: z.union([movieScrobbleResponseSchema, episodeScrobbleResponseSchema]),
+      201: z.union([
+        movieScrobbleResponseSchema,
+        episodeScrobbleResponseSchema,
+      ]),
     },
   },
 }, {
@@ -77,5 +85,9 @@ export {
 
 export type MovieScrobbleRequest = z.infer<typeof movieScrobbleRequestSchema>;
 export type MovieScrobbleResponse = z.infer<typeof movieScrobbleResponseSchema>;
-export type EpisodeScrobbleRequest = z.infer<typeof episodeScrobbleRequestSchema>;
-export type EpisodeScrobbleResponse = z.infer<typeof episodeScrobbleResponseSchema>;
+export type EpisodeScrobbleRequest = z.infer<
+  typeof episodeScrobbleRequestSchema
+>;
+export type EpisodeScrobbleResponse = z.infer<
+  typeof episodeScrobbleResponseSchema
+>;

--- a/projects/api/src/contracts/users/schema/response/ratedItemResponseSchema.ts
+++ b/projects/api/src/contracts/users/schema/response/ratedItemResponseSchema.ts
@@ -25,6 +25,21 @@ const ratedEpisodesResponseSchema = ratedResponseSchema.extend({
   }).nullish(),
 });
 
+const ratedSeasonResponseSchema = ratedResponseSchema.extend({
+  type: z.literal('season'),
+  season: z.object({
+    number: z.number().int(),
+    ids: episodeIdsResponseSchema,
+    aired_episodes: z.number().int(),
+  }).nullish(),
+  show: z.object({
+    title: z.string(),
+    year: z.number().int().nullish(),
+    aired_episodes: z.number().int(),
+    ids: showIdsResponseSchema,
+  }).nullish(),
+});
+
 const ratedMoviesResponseSchema = ratedResponseSchema
   .merge(z.object({
     type: z.literal('movie'),
@@ -41,4 +56,5 @@ export const RatedItemResponseSchema = z.union([
   ratedEpisodesResponseSchema,
   ratedMoviesResponseSchema,
   ratedShowsResponseSchema,
+  ratedSeasonResponseSchema,
 ]);

--- a/projects/api/src/contracts/users/subroutes/ratings.ts
+++ b/projects/api/src/contracts/users/subroutes/ratings.ts
@@ -1,5 +1,6 @@
 import { builder } from '../../_internal/builder.ts';
 import { extendedMediaQuerySchema } from '../../_internal/request/extendedMediaQuerySchema.ts';
+import { pageQuerySchema } from '../../_internal/request/pageQuerySchema.ts';
 import type { z } from '../../_internal/z.ts';
 import { profileParamsSchema } from '../schema/request/profileParamsSchema.ts';
 import { RatedItemResponseSchema } from '../schema/response/ratedItemResponseSchema.ts';
@@ -12,7 +13,8 @@ Returns movies rated by a user including each rating value and when it was rated
     path: '/movies',
     pathParams: profileParamsSchema,
     method: 'GET',
-    query: extendedMediaQuerySchema,
+    query: extendedMediaQuerySchema
+      .merge(pageQuerySchema),
     responses: {
       200: RatedItemResponseSchema.array(),
     },
@@ -24,7 +26,8 @@ Returns shows rated by a user including each rating value and when it was rated.
     path: '/shows',
     pathParams: profileParamsSchema,
     method: 'GET',
-    query: extendedMediaQuerySchema,
+    query: extendedMediaQuerySchema
+      .merge(pageQuerySchema),
     responses: {
       200: RatedItemResponseSchema.array(),
     },
@@ -36,7 +39,21 @@ Returns episodes rated by a user including each rating value and when it was rat
     path: '/episodes',
     pathParams: profileParamsSchema,
     method: 'GET',
-    query: extendedMediaQuerySchema,
+    query: extendedMediaQuerySchema
+      .merge(pageQuerySchema),
+    responses: {
+      200: RatedItemResponseSchema.array(),
+    },
+  },
+  all: {
+    summary: 'Get all ratings',
+    description: `#### 🔓 OAuth Optional ✨ Extended Info
+Returns all ratings by a user including each rating value and when it was rated.`,
+    path: '/',
+    pathParams: profileParamsSchema,
+    method: 'GET',
+    query: extendedMediaQuerySchema
+      .merge(pageQuerySchema),
     responses: {
       200: RatedItemResponseSchema.array(),
     },


### PR DESCRIPTION
## 🎶 Notes 🎶
- Introduces a new endpoint to fetch all ratings for a user, consolidating various rating types.
- Enhances existing user ratings endpoints for movies, shows, and episodes by adding pagination support.
- Extends the `RatedItemResponseSchema` to include support for rated seasons, allowing more comprehensive rating retrieval.
- Removes an unused import to clean up the scrobble contract code.
- Bumps the API package version.