### PR TITLE
User Ratings: return full episode & show data in ratings responses

### DIFF
--- a/projects/api/deno.json
+++ b/projects/api/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@trakt/api",
   "exports": "./src/index.ts",
-  "version": "0.4.12",
+  "version": "0.4.13",
   "imports": {
     "@anatine/zod-openapi": "npm:@anatine/zod-openapi@^2.2.6",
     "@std/testing": "jsr:@std/testing@^1.0.5",

--- a/projects/api/src/contracts/users/schema/response/ratedItemResponseSchema.ts
+++ b/projects/api/src/contracts/users/schema/response/ratedItemResponseSchema.ts
@@ -1,6 +1,6 @@
 import { episodeIdsResponseSchema } from '../../../_internal/response/episodeIdsResponseSchema.ts';
+import { episodeResponseSchema } from '../../../_internal/response/episodeResponseSchema.ts';
 import { movieResponseSchema } from '../../../_internal/response/movieResponseSchema.ts';
-import { showIdsResponseSchema } from '../../../_internal/response/showIdsResponseSchema.ts';
 import { showResponseSchema } from '../../../_internal/response/showResponseSchema.ts';
 import { z } from '../../../_internal/z.ts';
 
@@ -11,18 +11,8 @@ const ratedResponseSchema = z.object({
 
 const ratedEpisodesResponseSchema = ratedResponseSchema.extend({
   type: z.literal('episode'),
-  episode: z.object({
-    season: z.number().int(),
-    number: z.number().int(),
-    title: z.string().nullish(),
-    ids: episodeIdsResponseSchema,
-  }).nullish(),
-  show: z.object({
-    title: z.string(),
-    year: z.number().int().nullish(),
-    aired_episodes: z.number().int(),
-    ids: showIdsResponseSchema,
-  }).nullish(),
+  episode: episodeResponseSchema.nullish(),
+  show: showResponseSchema.nullish(),
 });
 
 const ratedSeasonResponseSchema = ratedResponseSchema.extend({
@@ -32,12 +22,7 @@ const ratedSeasonResponseSchema = ratedResponseSchema.extend({
     ids: episodeIdsResponseSchema,
     aired_episodes: z.number().int(),
   }).nullish(),
-  show: z.object({
-    title: z.string(),
-    year: z.number().int().nullish(),
-    aired_episodes: z.number().int(),
-    ids: showIdsResponseSchema,
-  }).nullish(),
+  show: showResponseSchema.nullish(),
 });
 
 const ratedMoviesResponseSchema = ratedResponseSchema


### PR DESCRIPTION
## Summary

Episode and season rating items in `RatedItemResponseSchema` were typed with
minimal inline objects that omitted the `images` field (and most other
`extended=full` fields). Because Zod strips unknown keys, the screenshot and
fanart images the API actually returns were being **silently discarded** during
parsing — even when the request asked for `extended=full,images`.

This switches episode and season rating items to the full
`episodeResponseSchema` / `showResponseSchema`, matching how the movie and show
rating variants already work.

## Why

The `/users/:id/ratings` (and `/ratings/episodes`) endpoints return full
`episode` and `show` objects — including `images.screenshot` and
`images.fanart` — but the SDK schema reduced them to
`{ season, number, title, ids }` / `{ title, year, aired_episodes, ids }`.

As a result, consumers could never access episode screenshots or show fanart
for episode ratings, and also lost `overview`, `first_aired`, `runtime`,
`episode_type`, etc. The minimal shape was strictly a subset of what the API
delivers.

## Changes

- `ratedEpisodesResponseSchema`: `episode` → `episodeResponseSchema`,
  `show` → `showResponseSchema`
- `ratedSeasonResponseSchema`: `show` → `showResponseSchema`
- Drop the now-unused `showIdsResponseSchema` import
- Bump version `0.4.12` → `0.4.13`

## Impact

- ✅ Additive only — the previous minimal fields are a subset of the full
  schemas, so existing consumers keep working.
- Unlocks episode screenshots + show fanart (and full episode metadata) for
  ratings views in `trakt-web`.

Fixes the data side of trakt/trakt-web#2403.

## Verification

Parsed live `/users/:id/ratings?extended=full,images` payloads through the
updated schema — episode `images.screenshot` and show `images.fanart` are now
retained for all episode rating items (previously `undefined`).