### PR TITLE
Younify: adds all methods

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -57,6 +57,7 @@ module.exports = {
         'team',
         'user',
         'watchnow',
+        'younify',
       ],
     ],
     'type-case': [RuleConfigSeverity.Error, 'always', 'lower-case'],

--- a/projects/api/deno.json
+++ b/projects/api/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@trakt/api",
   "exports": "./src/index.ts",
-  "version": "0.4.13",
+  "version": "0.4.14",
   "imports": {
     "@anatine/zod-openapi": "npm:@anatine/zod-openapi@^2.2.6",
     "@std/testing": "jsr:@std/testing@^1.0.5",

--- a/projects/api/src/contracts/traktContract.ts
+++ b/projects/api/src/contracts/traktContract.ts
@@ -19,6 +19,7 @@ import { sync } from './sync/index.ts';
 import { team } from './team/index.ts';
 import { users } from './users/index.ts';
 import { watchnow } from './watchnow/index.ts';
+import { younify } from './younify/index.ts';
 
 export const traktContract = builder
   .router({
@@ -42,4 +43,5 @@ export const traktContract = builder
     certifications,
     scrobble,
     team,
+    younify,
   });

--- a/projects/api/src/contracts/users/index.ts
+++ b/projects/api/src/contracts/users/index.ts
@@ -17,6 +17,8 @@ import { profileParamsSchema } from './schema/request/profileParamsSchema.ts';
 import { settingsRequestSchema } from './schema/request/settingsRequestSchema.ts';
 import { socialActivityParamsSchema } from './schema/request/socialActivityParamsSchema.ts';
 import { sortEnumSchema } from './schema/request/sortParamsSchema.ts';
+import { syncIdParamsSchema } from './schema/request/syncIdParamsSchema.ts';
+import { syncTypeParamsSchema } from './schema/request/syncTypeParamsSchema.ts';
 import { userReportRequestSchema } from './schema/request/userReportRequestSchema.ts';
 import { yearInReviewParamsSchema } from './schema/request/yearInReviewParamsSchema.ts';
 import { blockedUserResponseSchema } from './schema/response/blockedUserResponseSchema.ts';
@@ -31,6 +33,8 @@ import { monthInReviewResponseSchema } from './schema/response/monthInReviewResp
 import { reactedCommentResponseSchema } from './schema/response/reactedCommentResponseSchema.ts';
 import { settingsResponseSchema } from './schema/response/settingsResponseSchema.ts';
 import { socialActivityResponseSchema } from './schema/response/socialActivityResponseSchema.ts';
+import { syncItemSchema } from './schema/response/syncItemResponseSchema.ts';
+import { syncSchema } from './schema/response/syncResponseSchema.ts';
 import { userCommentResponseSchema } from './schema/response/userCommentResponseSchema.ts';
 import { userStatsResponseSchema } from './schema/response/userStatsResponseSchema.ts';
 import { watchActionSchema } from './schema/response/watchActionSchema.ts';
@@ -45,8 +49,8 @@ import { requests } from './subroutes/requests.ts';
 import { userLists } from './subroutes/userLists.ts';
 import { watched } from './subroutes/watched.ts';
 import { watchlist } from './subroutes/watchlist.ts';
-import { mediaFilterParamsSchema } from "../_internal/request/mediaFilterParamsSchema.ts";
-import { ignoreQuerySchema } from "../_internal/request/ignoreQuerySchema.ts";
+import { mediaFilterParamsSchema } from '../_internal/request/mediaFilterParamsSchema.ts';
+import { ignoreQuerySchema } from '../_internal/request/ignoreQuerySchema.ts';
 
 const GLOBAL_LEVEL = builder.router({
   settings: {
@@ -156,6 +160,95 @@ Returns all users you have blocked, including when each user was blocked.`,
       200: blockedUserResponseSchema.array(),
     },
   },
+});
+
+const syncs = builder.router({
+  list: {
+    summary: 'Get data syncs',
+    description: `#### 🔒 OAuth Required 📄 Pagination
+Paginated list of the authenticated user's data syncs across **every** connected app (younify, plex, importers). Counts only — the paused/skipped item arrays are served by the dedicated paginated endpoints.
+
+Pagination is via \`page\` / \`limit\` and the standard \`X-Pagination-*\` headers. \`X-Pagination-Item-Count\` is the total sync count (use it for the "Data has synced N times" banner). All timestamps are normalized to \`.000Z\`.`,
+    method: 'GET',
+    path: '/',
+    query: pageQuerySchema,
+    responses: {
+      200: syncSchema.array(),
+    },
+  },
+  listByType: {
+    summary: 'Get data syncs by type',
+    description: `#### 🔒 OAuth Required 📄 Pagination
+Same as the list of data syncs, filtered by the app that created them. The \`type\` matches the \`kind\` returned on each row (\`younify\`, \`plex\`, or \`import\` for anything else, including \`application_id 0\` importers).
+
+An unknown \`type\` returns \`404\` rather than silently returning everything. Pagination and \`X-Pagination-*\` headers are identical to the unfiltered list.`,
+    method: 'GET',
+    path: '/:type',
+    pathParams: syncTypeParamsSchema,
+    query: pageQuerySchema,
+    responses: {
+      200: syncSchema.array(),
+      404: z.undefined(),
+    },
+  },
+  details: {
+    summary: 'Get a data sync',
+    description: `#### 🔒 OAuth Required
+Returns a single sync scoped to the authenticated user — foreign ids return \`404\`. Same shape as a list row: added counts plus \`paused_count\` / \`skipped_count\`, no item arrays.
+
+A numeric segment (\`/users/syncs/157\`) hits this endpoint; a non-numeric segment (\`/users/syncs/younify\`) is the filtered list.`,
+    method: 'GET',
+    path: '/:id',
+    pathParams: syncIdParamsSchema,
+    responses: {
+      200: syncSchema,
+      404: z.undefined(),
+    },
+  },
+  paused: {
+    summary: 'Get paused sync items',
+    description: `#### 🔒 OAuth Required 📄 Pagination
+Paginated item array for a sync, scoped to the authenticated user — foreign ids return \`404\`. Split out because a single sync can hold thousands of items.
+
+Paused items are always \`history\` (their \`kind\` is always \`"history"\`). Each item is the raw stored item (so source-specific fields are preserved) plus a normalized envelope, with timestamps normalized to \`.000Z\`. Pagination and \`X-Pagination-*\` headers are identical to the list endpoint.`,
+    method: 'GET',
+    path: '/:id/paused',
+    pathParams: syncIdParamsSchema,
+    query: pageQuerySchema,
+    responses: {
+      200: syncItemSchema.array(),
+      404: z.undefined(),
+    },
+  },
+  skipped: {
+    summary: 'Get skipped sync items',
+    description: `#### 🔒 OAuth Required 📄 Pagination
+Paginated item array for a sync, scoped to the authenticated user — foreign ids return \`404\`. Split out because a single sync can hold thousands of items.
+
+Skipped items mix \`history\` and \`rating\` (see each item's \`kind\` discriminator). Each item is the raw stored item (so source-specific fields are preserved) plus a normalized envelope, with timestamps normalized to \`.000Z\`. Pagination and \`X-Pagination-*\` headers are identical to the list endpoint.`,
+    method: 'GET',
+    path: '/:id/skipped',
+    pathParams: syncIdParamsSchema,
+    query: pageQuerySchema,
+    responses: {
+      200: syncItemSchema.array(),
+      404: z.undefined(),
+    },
+  },
+  undo: {
+    summary: 'Undo a data sync',
+    description: `#### 🔒 OAuth Required
+Undoes a sync — reverses every item it imported (history, ratings, paused, watchlist, collection) and marks it undone. Scoped to the authenticated user; a foreign sync returns \`404\`.`,
+    method: 'DELETE',
+    path: '/:id',
+    pathParams: syncIdParamsSchema,
+    responses: {
+      204: z.undefined(),
+      404: z.undefined(),
+    },
+  },
+}, {
+  pathPrefix: '/syncs',
 });
 
 const ENTITY_LEVEL = builder.router({
@@ -371,6 +464,7 @@ Returns a year-in-review summary for a user. Send the \`year\` path parameter to
 
 export const users = builder.router({
   ...GLOBAL_LEVEL,
+  syncs,
   ...ENTITY_LEVEL,
   watched,
   history,
@@ -415,6 +509,10 @@ export {
   settingsResponseSchema,
   socialActivityResponseSchema,
   sortEnumSchema,
+  syncIdParamsSchema,
+  syncItemSchema,
+  syncSchema,
+  syncTypeParamsSchema,
   userCommentResponseSchema,
   userReportRequestSchema,
   userStatsResponseSchema,
@@ -466,3 +564,8 @@ export type YearInReviewResponse = z.infer<typeof yearInReviewResponseSchema>;
 export type ReactedCommentResponse = z.infer<
   typeof reactedCommentResponseSchema
 >;
+
+export type SyncResponse = z.infer<typeof syncSchema>;
+export type SyncItemResponse = z.infer<typeof syncItemSchema>;
+export type SyncTypeParams = z.infer<typeof syncTypeParamsSchema>;
+export type SyncIdParams = z.infer<typeof syncIdParamsSchema>;

--- a/projects/api/src/contracts/users/schema/request/syncIdParamsSchema.ts
+++ b/projects/api/src/contracts/users/schema/request/syncIdParamsSchema.ts
@@ -1,0 +1,8 @@
+import { z } from '../../../_internal/z.ts';
+
+export const syncIdParamsSchema = z.object({
+  id: z.number().int().openapi({
+    description:
+      'The numeric sync id, scoped to the authenticated user. A numeric segment hits a single sync; a non-numeric segment is the filtered list.',
+  }),
+});

--- a/projects/api/src/contracts/users/schema/request/syncTypeParamsSchema.ts
+++ b/projects/api/src/contracts/users/schema/request/syncTypeParamsSchema.ts
@@ -1,0 +1,8 @@
+import { z } from '../../../_internal/z.ts';
+
+export const syncTypeParamsSchema = z.object({
+  type: z.enum(['younify', 'plex', 'import']).openapi({
+    description:
+      'Filter syncs by the app that created them. An unknown type returns `404` rather than silently returning everything.',
+  }),
+});

--- a/projects/api/src/contracts/users/schema/response/syncItemResponseSchema.ts
+++ b/projects/api/src/contracts/users/schema/response/syncItemResponseSchema.ts
@@ -1,0 +1,71 @@
+import { float, z } from '../../../_internal/z.ts';
+
+const movieVariantSchema = z.object({
+  type: z.literal('movie'),
+  title: z.string(),
+  year: z.number().int(),
+  ids: z.object({
+    trakt: z.number().int(),
+    slug: z.string(),
+    imdb: z.string().nullable(),
+    tmdb: z.number().int().nullable(),
+  }),
+});
+
+const showVariantSchema = z.object({
+  type: z.literal('show'),
+  title: z.string(),
+  year: z.number().int(),
+  ids: z.object({
+    trakt: z.number().int(),
+    slug: z.string(),
+  }),
+});
+
+const episodeVariantSchema = z.object({
+  type: z.literal('episode'),
+  season: z.number().int(),
+  number: z.number().int(),
+  title: z.string(),
+  ids: z.object({
+    trakt: z.number().int(),
+    tmdb: z.number().int().nullable(),
+  }),
+  show: showVariantSchema.nullable(),
+});
+
+export const traktItemSchema = z.discriminatedUnion('type', [
+  movieVariantSchema,
+  showVariantSchema,
+  episodeVariantSchema,
+]);
+
+export const syncItemSchema = z.object({
+  kind: z.enum(['history', 'rating']).openapi({
+    description:
+      'Discriminator. `skipped` mixes `history` and `rating`; `paused` is always `history`.',
+  }),
+  type: z.enum(['movie', 'episode', 'show']).nullable().openapi({
+    description:
+      'Resolved media type, or null when it could not be derived from the available ids.',
+  }),
+  trakt_item: traktItemSchema.nullable().openapi({
+    description:
+      'Resolved trakt object when a tmdb id matches, null otherwise.',
+  }),
+  // younify fields — all nullish, plex items won't carry them.
+  service_id: z.string().nullish(),
+  content_id: z.string().nullish(),
+  profile_id: z.string().nullish(),
+  tmdb_id: z.number().int().nullish(),
+  tmdb_series_id: z.number().int().nullish(),
+  watched_at: z.string().datetime().nullish().openapi({
+    description: 'History timestamp, normalized to `.000Z`.',
+  }),
+  rated_at: z.string().datetime().nullish().openapi({
+    description: 'Rating timestamp, normalized to `.000Z`.',
+  }),
+  progress: float(z.number()).nullish(),
+  rating_type: z.string().nullish(),
+  rating_value: z.number().int().nullish(),
+}).passthrough();

--- a/projects/api/src/contracts/users/schema/response/syncResponseSchema.ts
+++ b/projects/api/src/contracts/users/schema/response/syncResponseSchema.ts
@@ -1,0 +1,39 @@
+import { z } from '../../../_internal/z.ts';
+
+const countBlock = z.object({
+  movies: z.number().int().optional(),
+  episodes: z.number().int().optional(),
+  shows: z.number().int().optional(),
+  seasons: z.number().int().optional(),
+});
+
+export const syncSchema = z.object({
+  id: z.number().int(),
+  created_at: z.string().datetime().openapi({
+    description: 'When the sync ran, normalized to `.000Z`.',
+  }),
+  kind: z.enum(['younify', 'plex', 'import']),
+  source: z.string().nullable().openapi({
+    description:
+      'Streaming service / importer source (`netflix`, `plex`, `csv`, …), or null.',
+  }),
+  application: z.string().nullable().openapi({
+    description:
+      'Name of the OAuth app that created the sync; null for `application_id 0` importers.',
+  }),
+  undone: z.boolean(),
+  undone_at: z.string().datetime().nullable().openapi({
+    description: 'When the sync was reversed, normalized to `.000Z`, or null.',
+  }),
+  items: z.object({
+    history: countBlock.optional(),
+    library: countBlock.optional(),
+    ratings: countBlock.optional(),
+    watchlist: countBlock.optional(),
+  }).openapi({
+    description:
+      'Added counts per section. Empty sections and media types are omitted.',
+  }),
+  paused_count: z.number().int(),
+  skipped_count: z.number().int(),
+});

--- a/projects/api/src/contracts/younify/index.ts
+++ b/projects/api/src/contracts/younify/index.ts
@@ -1,0 +1,90 @@
+import { authMetadata, builder } from '../_internal/builder.ts';
+import { z } from '../_internal/z.ts';
+import { connectRequestSchema } from './schema/request/connectRequestSchema.ts';
+import { refreshParamsSchema } from './schema/request/refreshParamsSchema.ts';
+import { serviceIdParamsSchema } from './schema/request/serviceIdParamsSchema.ts';
+import { connectionSchema } from './schema/response/connectionResponseSchema.ts';
+import { connectResponseSchema } from './schema/response/connectResponseSchema.ts';
+
+export const younify = builder.router({
+  connections: {
+    summary: 'Get streaming connections',
+    description: `#### 🔒 OAuth Required
+Lists every connectable streaming service with the current user's connection status merged in, so a settings grid can render each tile in one pass. Read-only — never creates a remote younify user.
+
+> ### IMPORTANT
+> _**Array order is significant.** Clients must preserve the response order when rendering the grid; the list is returned in the intended display order._
+
+\`vip: false\` is the free tier. \`connectable\` reflects whether the current user may connect the service on their plan. \`connected\` plus \`active\` indicate a healthy link (\`active: false\` is a broken link). \`profile\` and \`last_synced_at\` are null when not connected, and \`last_synced_at\` is normalized to \`.000Z\`.`,
+    method: 'GET',
+    path: '/connections',
+    responses: {
+      200: connectionSchema.array(),
+    },
+  },
+  connect: {
+    summary: 'Create a streaming connection',
+    description: `#### 🔒 OAuth Required
+Mints a signed younify web-auth URL for the client to open. Accepts the client's own \`return_url\` (deep link / universal link), validated against trakt-owned destinations only (\`trakt://…\` or \`https://*.trakt.tv\`).
+
+A \`422\` is returned when the service is not connectable on the user's plan, and a \`400\` when the \`return_url\` is missing/invalid or no URL could be minted.`,
+    method: 'POST',
+    path: '/connect',
+    body: connectRequestSchema,
+    responses: {
+      200: connectResponseSchema,
+      400: z.undefined(),
+      422: z.undefined(),
+    },
+  },
+  refresh: {
+    summary: 'Refresh a streaming service',
+    description: `#### 🔒 OAuth Required
+Queue / force a re-sync of a connected streaming service for the authenticated user.`,
+    method: 'POST',
+    path: '/users/refresh/:service_id',
+    pathParams: serviceIdParamsSchema,
+    body: z.undefined(),
+    responses: {
+      204: z.undefined(),
+    },
+  },
+  refreshAll: {
+    summary: 'Refresh a streaming service (full re-sync)',
+    description: `#### 🔒 OAuth Required
+Queue / force a re-sync of a connected streaming service for the authenticated user. The trailing \`all_data\` segment forces a full re-sync of all data rather than an incremental one.`,
+    method: 'POST',
+    path: '/users/refresh/:service_id/:all_data',
+    pathParams: refreshParamsSchema,
+    body: z.undefined(),
+    responses: {
+      204: z.undefined(),
+    },
+  },
+  disconnect: {
+    summary: 'Unlink a streaming service',
+    description: `#### 🔒 OAuth Required
+Unlink a streaming service from the authenticated user.`,
+    method: 'DELETE',
+    path: '/users/services/:service_id',
+    pathParams: serviceIdParamsSchema,
+    responses: {
+      204: z.undefined(),
+    },
+  },
+}, {
+  pathPrefix: '/younify',
+  metadata: authMetadata('required'),
+});
+
+export {
+  connectionSchema,
+  connectRequestSchema,
+  connectResponseSchema,
+  refreshParamsSchema,
+  serviceIdParamsSchema,
+};
+
+export type YounifyConnection = z.infer<typeof connectionSchema>;
+export type YounifyConnectRequest = z.infer<typeof connectRequestSchema>;
+export type YounifyConnectResponse = z.infer<typeof connectResponseSchema>;

--- a/projects/api/src/contracts/younify/schema/request/connectRequestSchema.ts
+++ b/projects/api/src/contracts/younify/schema/request/connectRequestSchema.ts
@@ -1,0 +1,11 @@
+import { z } from '../../../_internal/z.ts';
+
+export const connectRequestSchema = z.object({
+  service_id: z.string().openapi({
+    description: 'The streaming service to connect (e.g. `netflix`).',
+  }),
+  return_url: z.string().openapi({
+    description:
+      'Where the younify web-auth flow returns the user once complete. Must be a trakt-owned destination (`trakt://…` or `https://*.trakt.tv`).',
+  }),
+});

--- a/projects/api/src/contracts/younify/schema/request/refreshParamsSchema.ts
+++ b/projects/api/src/contracts/younify/schema/request/refreshParamsSchema.ts
@@ -1,0 +1,11 @@
+import { z } from '../../../_internal/z.ts';
+
+export const refreshParamsSchema = z.object({
+  service_id: z.string().openapi({
+    description: 'The streaming service id to re-sync (e.g. `netflix`).',
+  }),
+  all_data: z.string().openapi({
+    description:
+      'Optional trailing segment that forces a full re-sync of all data rather than an incremental one.',
+  }),
+});

--- a/projects/api/src/contracts/younify/schema/request/serviceIdParamsSchema.ts
+++ b/projects/api/src/contracts/younify/schema/request/serviceIdParamsSchema.ts
@@ -1,0 +1,7 @@
+import { z } from '../../../_internal/z.ts';
+
+export const serviceIdParamsSchema = z.object({
+  service_id: z.string().openapi({
+    description: 'The streaming service id (e.g. `netflix`).',
+  }),
+});

--- a/projects/api/src/contracts/younify/schema/response/connectResponseSchema.ts
+++ b/projects/api/src/contracts/younify/schema/response/connectResponseSchema.ts
@@ -1,0 +1,7 @@
+import { z } from '../../../_internal/z.ts';
+
+export const connectResponseSchema = z.object({
+  url: z.string().openapi({
+    description: 'The signed younify web-auth URL for the client to open.',
+  }),
+});

--- a/projects/api/src/contracts/younify/schema/response/connectionResponseSchema.ts
+++ b/projects/api/src/contracts/younify/schema/response/connectionResponseSchema.ts
@@ -1,0 +1,33 @@
+import { z } from '../../../_internal/z.ts';
+
+export const connectionSchema = z.object({
+  id: z.string().openapi({
+    description: 'The streaming service id (e.g. `netflix`).',
+  }),
+  name: z.string(),
+  vip: z.boolean().openapi({
+    description:
+      'Whether the service requires Trakt VIP. `false` is the free tier.',
+  }),
+  color: z.string(),
+  images: z.object({
+    logo: z.string().nullable(),
+  }),
+  connectable: z.boolean().openapi({
+    description:
+      'Whether the current user may connect this service (VIP gating). Use to show Connect vs an upsell.',
+  }),
+  connected: z.boolean().openapi({
+    description: 'Whether the service is linked for the current user.',
+  }),
+  active: z.boolean().openapi({
+    description: 'Whether the link is healthy. `false` means a broken link.',
+  }),
+  profile: z.string().nullable().openapi({
+    description: 'The connected profile name, or null when not connected.',
+  }),
+  last_synced_at: z.string().datetime().nullable().openapi({
+    description:
+      'When the service last synced, normalized to `.000Z`, or null when not connected.',
+  }),
+});

--- a/projects/api/src/index.ts
+++ b/projects/api/src/index.ts
@@ -21,6 +21,7 @@ export * from './contracts/sync/index.ts';
 export * from './contracts/team/index.ts';
 export * from './contracts/users/index.ts';
 export * from './contracts/watchnow/index.ts';
+export * from './contracts/younify/index.ts';
 
 export { Environment, traktContract };
 


### PR DESCRIPTION
# Description

Wires the newly-merged **v2 younify streaming-sync management** endpoints into the `@trakt/api` ts-rest contracts, so native clients can port the web `/settings/scrobblers` ("Streaming Sync") page.

All routes require an official Trakt app API key **and** a user OAuth token, consistent with the existing `/younify/*` endpoints.

**1. New top-level `younify` contract** (`/younify`, `authMetadata('required')`)

| Route | Method & Path | Response |
|---|---|---|
| `connections` | `GET /younify/connections` | `200` → `connectionSchema[]` |
| `connect` | `POST /younify/connect` | `200` → `{ url }`, `400`/`422` |
| `refresh` | `POST /younify/users/refresh/:service_id` | `204` |
| `refreshAll` | `POST /younify/users/refresh/:service_id/:all_data` | `204` |
| `disconnect` | `DELETE /younify/users/services/:service_id` | `204` |

- `connections` returns every connectable service with the user's status merged in. **Array order is significant** — clients must preserve response order when rendering the grid (documented in the route description).
- `connect` mints a signed younify web-auth URL from the client's `return_url`.
- `refresh`/`refreshAll`/`disconnect` are the existing reused actions the native page depends on (they weren't yet in the contract). The optional Rails segment `(/:all_data)` is modeled as a second explicit route (`refreshAll`), since ts-rest can't express truly-optional path segments.

**2. New `syncs` sub-router on the `users` contract** (collection-level, `/users/syncs`)

| Route | Method & Path | Response |
|---|---|---|
| `list` | `GET /users/syncs` | `200` → `syncSchema[]` |
| `listByType` | `GET /users/syncs/:type` | `200` → `syncSchema[]` |
| `details` | `GET /users/syncs/:id` | `200` → `syncSchema` |
| `paused` | `GET /users/syncs/:id/paused` | `200` → `syncItemSchema[]` |
| `skipped` | `GET /users/syncs/:id/skipped` | `200` → `syncItemSchema[]` |
| `undo` | `DELETE /users/syncs/:id` | `204` |

- Paginated via `pageQuerySchema` + standard `X-Pagination-*` headers (`X-Pagination-Item-Count` = total sync count for the "synced N times" banner).
- `syncSchema` is counts-only (added counts + `paused_count`/`skipped_count`); the potentially-huge paused/skipped item arrays are split into their own paginated routes.
- `syncItemSchema` is the raw stored item + a normalized envelope, made permissive with `.passthrough()` (preserves source-specific plex fields) and a discriminated `trakt_item`. `kind` discriminates `history` vs `rating` (paused is always `history`; skipped mixes both).
- Timestamps are documented as API-standard `.000Z`; an unknown `:type` 404s; `:id`/`:type` path collision is fine (ts-rest dispatches by route key).

**Conventions:** placed alongside the existing inline `GLOBAL_LEVEL`/`ENTITY_LEVEL` routers in `users/index.ts`; one schema per file under `schema/request|response`; `#### 🔒 OAuth Required` descriptions; `z.infer` type aliases + schema re-exports; error responses use `z.undefined()` to match the repo-wide norm. Registered in both `traktContract.ts` and `src/index.ts`, and bumped `@trakt/api` to `0.4.14`.

# Testing

- `deno check src/index.ts` — passes.
- `deno lint` + `deno fmt --check` — clean on all changed files.
- OpenAPI `generate` + `validate` — pass; all 9 new paths appear in the generated spec (`.passthrough()` and discriminated unions generate valid OpenAPI).

> Note: `deno test` surfaces 5 **pre-existing** type errors in `sync/HistoryRequest.test.ts`, unrelated to this change.

# Checklist
- [x] Clear and concise title
- [x] Detailed description
- [x] Coding standards (`deno fmt`/`deno lint` clean)
- [x] Documentation (OpenAPI regenerated & validated)
- [x] Tests — no new contract tests added (consistent with existing contract additions, e.g. #797)
