### PR TITLE
Plex Sync: adds all methods

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -49,6 +49,7 @@ module.exports = {
         'movie',
         'oauth',
         'person',
+        'plex',
         'recommendation',
         'scrobble',
         'search',

--- a/projects/api/deno.json
+++ b/projects/api/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@trakt/api",
   "exports": "./src/index.ts",
-  "version": "0.4.15",
+  "version": "0.4.16",
   "imports": {
     "@anatine/zod-openapi": "npm:@anatine/zod-openapi@^2.2.6",
     "@std/testing": "jsr:@std/testing@^1.0.5",

--- a/projects/api/src/contracts/users/index.ts
+++ b/projects/api/src/contracts/users/index.ts
@@ -13,6 +13,10 @@ import { commentsRequestSchema } from './schema/request/commentsRequestSchema.ts
 import { commentTypeParamsSchema } from './schema/request/commentTypeParamsSchema.ts';
 import { coverRequestSchema } from './schema/request/coverRequestSchema.ts';
 import { monthInReviewParamsSchema } from './schema/request/monthInReviewParamsSchema.ts';
+import { plexConnectRequestSchema } from './schema/request/plexConnectRequestSchema.ts';
+import { plexServerParamsSchema } from './schema/request/plexServerParamsSchema.ts';
+import { plexSettingsUpdateSchema } from './schema/request/plexSettingsUpdateSchema.ts';
+import { plexSyncRequestSchema } from './schema/request/plexSyncRequestSchema.ts';
 import { profileParamsSchema } from './schema/request/profileParamsSchema.ts';
 import { settingsRequestSchema } from './schema/request/settingsRequestSchema.ts';
 import { socialActivityParamsSchema } from './schema/request/socialActivityParamsSchema.ts';
@@ -30,6 +34,18 @@ import {
   likedListResponseSchema,
 } from './schema/response/likedItemResponseSchema.ts';
 import { monthInReviewResponseSchema } from './schema/response/monthInReviewResponseSchema.ts';
+import { plexConnectResponseSchema } from './schema/response/plexConnectResponseSchema.ts';
+import { plexErrorResponseSchema } from './schema/response/plexErrorResponseSchema.ts';
+import {
+  plexAccountSchema,
+  plexLibrarySchema,
+  plexServerAccountsResponseSchema,
+} from './schema/response/plexServerAccountsResponseSchema.ts';
+import {
+  plexServerSchema,
+  plexServersResponseSchema,
+} from './schema/response/plexServersResponseSchema.ts';
+import { plexSettingsResponseSchema } from './schema/response/plexSettingsResponseSchema.ts';
 import { reactedCommentResponseSchema } from './schema/response/reactedCommentResponseSchema.ts';
 import { settingsResponseSchema } from './schema/response/settingsResponseSchema.ts';
 import { socialActivityResponseSchema } from './schema/response/socialActivityResponseSchema.ts';
@@ -251,6 +267,104 @@ Undoes a sync — reverses every item it imported (history, ratings, paused, wat
   pathPrefix: '/syncs',
 });
 
+const plex = builder.router({
+  settings: {
+    summary: 'Get Plex settings',
+    description: `#### 🔒 OAuth Required
+Returns the authenticated user's Plex connection status, real-time scrobbler webhook info, server/library/home-user selection, and both toggle sets (batch \`sync\` + real-time \`scrobbler\`). Read-only, though the VIP webhook URL lazily mints its tokens.
+
+\`connection.connected\` reflects that a Plex authorization exists; for a live auth check call \`servers\` and watch for a \`bad_auth\` error. \`webhook.url\` is null unless the user is VIP. \`sync.configured\` indicates the initial sync has been set up. Toggles are booleans (unset ⇒ \`false\`); sync toggles include \`watching\`/\`watchlist\`, scrobbler toggles do not carry \`watchlist\`. All timestamps are normalized to \`.000Z\`.`,
+    method: 'GET',
+    path: '/',
+    responses: {
+      200: plexSettingsResponseSchema,
+    },
+  },
+  updateSettings: {
+    summary: 'Update Plex settings',
+    description: `#### 🔒 OAuth Required
+Writes the Plex toggles, selection, and home users. Mirrors the GET shape so it round-trips; omitted toggle keys are left unchanged (no clobbering), and \`library_ids\` is sent structured and rebuilt into the \`server|uuid\` storage server-side.
+
+The optional \`trigger_sync\` block is the only thing that touches sync timestamps or enqueues work: any \`*_all_data: true\` resets the affected cursors and enqueues a full sync per selected server; present-but-all-false seeds every cursor to "now" (the first sync skips old history); absent writes settings without syncing.`,
+    method: 'PUT',
+    path: '/',
+    body: plexSettingsUpdateSchema,
+    responses: {
+      204: z.undefined(),
+    },
+  },
+  connect: {
+    summary: 'Connect Plex',
+    description: `#### 🔒 OAuth Required
+Mints a Plex web-auth URL for the client to open. Plex uses a 2-step PIN OAuth; the PIN is stashed server-side under an opaque \`state\` token and Plex is forwarded to a website return endpoint that exchanges it and redirects back to your \`return_url\` with \`?plex_status=connected|error\`.
+
+\`return_url\` is validated against the trakt-owned allowlist (\`trakt://\`, \`http(s)://localhost\`, \`https://*.trakt.tv\`); a \`400\` is returned otherwise.`,
+    method: 'POST',
+    path: '/connect',
+    body: plexConnectRequestSchema,
+    responses: {
+      200: plexConnectResponseSchema,
+      400: z.undefined(),
+    },
+  },
+  disconnect: {
+    summary: 'Disconnect Plex',
+    description: `#### 🔒 OAuth Required
+Disconnects Plex: destroys the authorization, clears server/library/user selection and sync state, and busts the connection caches.`,
+    method: 'DELETE',
+    path: '/connect',
+    responses: {
+      204: z.undefined(),
+    },
+  },
+  servers: {
+    summary: 'Get Plex servers',
+    description: `#### 🔒 OAuth Required
+Lists the authenticated user's Plex servers. Network-bound — probes each server's remote URL. On a Plex/auth failure it returns the shared \`{ error_code, message, guidance }\` envelope: \`bad_auth\` (401), \`plex_timeout\` (504), \`plex_bad_response\`/\`plex_generic_error\` (502).`,
+    method: 'GET',
+    path: '/servers',
+    responses: {
+      200: plexServersResponseSchema,
+      401: plexErrorResponseSchema,
+      502: plexErrorResponseSchema,
+      504: plexErrorResponseSchema,
+    },
+  },
+  serverAccounts: {
+    summary: 'Get Plex server accounts and libraries',
+    description: `#### 🔒 OAuth Required
+Returns the home accounts (owned servers only) and syncable libraries for a Plex server, with the user's current library selection flagged. Network-bound.
+
+Errors use the shared \`{ error_code, message, guidance }\` envelope: \`missing_token\`/\`bad_auth\` (401), \`missing_server_id\`/\`plex_unprocessable\` (422), \`invalid_server_id\`/\`plex_not_found\` (404), \`invalid_server_url\` (503), \`plex_timeout\` (504), \`plex_bad_response\`/\`plex_generic_error\` (502).`,
+    method: 'GET',
+    path: '/servers/:server_id',
+    pathParams: plexServerParamsSchema,
+    responses: {
+      200: plexServerAccountsResponseSchema,
+      401: plexErrorResponseSchema,
+      404: plexErrorResponseSchema,
+      422: plexErrorResponseSchema,
+      502: plexErrorResponseSchema,
+      503: plexErrorResponseSchema,
+      504: plexErrorResponseSchema,
+    },
+  },
+  sync: {
+    summary: 'Sync Plex now',
+    description: `#### 🔒 OAuth Required
+Enqueues a Plex sync immediately. With \`server_id\`, syncs that server; without it, syncs every server in the saved selection. \`all_data: true\` re-pulls full history, otherwise an incremental sync. A \`422\` is returned when there is no server to sync.`,
+    method: 'POST',
+    path: '/sync',
+    body: plexSyncRequestSchema,
+    responses: {
+      201: z.undefined(),
+      422: z.undefined(),
+    },
+  },
+}, {
+  pathPrefix: '/settings/plex',
+});
+
 const ENTITY_LEVEL = builder.router({
   profile: {
     summary: 'Get user profile',
@@ -465,6 +579,7 @@ Returns a year-in-review summary for a user. Send the \`year\` path parameter to
 export const users = builder.router({
   ...GLOBAL_LEVEL,
   syncs,
+  plex,
   ...ENTITY_LEVEL,
   watched,
   history,
@@ -503,6 +618,18 @@ export {
   likedListResponseSchema,
   monthInReviewParamsSchema,
   monthInReviewResponseSchema,
+  plexAccountSchema,
+  plexConnectRequestSchema,
+  plexConnectResponseSchema,
+  plexErrorResponseSchema,
+  plexLibrarySchema,
+  plexServerAccountsResponseSchema,
+  plexServerParamsSchema,
+  plexServerSchema,
+  plexServersResponseSchema,
+  plexSettingsResponseSchema,
+  plexSettingsUpdateSchema,
+  plexSyncRequestSchema,
   profileParamsSchema,
   reactedCommentResponseSchema,
   settingsRequestSchema,
@@ -569,3 +696,20 @@ export type SyncResponse = z.infer<typeof syncSchema>;
 export type SyncItemResponse = z.infer<typeof syncItemSchema>;
 export type SyncTypeParams = z.infer<typeof syncTypeParamsSchema>;
 export type SyncIdParams = z.infer<typeof syncIdParamsSchema>;
+
+export type PlexSettingsResponse = z.infer<typeof plexSettingsResponseSchema>;
+export type PlexSettingsUpdateRequest = z.infer<
+  typeof plexSettingsUpdateSchema
+>;
+export type PlexConnectRequest = z.infer<typeof plexConnectRequestSchema>;
+export type PlexConnectResponse = z.infer<typeof plexConnectResponseSchema>;
+export type PlexServersResponse = z.infer<typeof plexServersResponseSchema>;
+export type PlexServer = z.infer<typeof plexServerSchema>;
+export type PlexServerAccountsResponse = z.infer<
+  typeof plexServerAccountsResponseSchema
+>;
+export type PlexAccount = z.infer<typeof plexAccountSchema>;
+export type PlexLibrary = z.infer<typeof plexLibrarySchema>;
+export type PlexServerParams = z.infer<typeof plexServerParamsSchema>;
+export type PlexSyncRequest = z.infer<typeof plexSyncRequestSchema>;
+export type PlexError = z.infer<typeof plexErrorResponseSchema>;

--- a/projects/api/src/contracts/users/schema/request/plexConnectRequestSchema.ts
+++ b/projects/api/src/contracts/users/schema/request/plexConnectRequestSchema.ts
@@ -1,0 +1,8 @@
+import { z } from '../../../_internal/z.ts';
+
+export const plexConnectRequestSchema = z.object({
+  return_url: z.string().openapi({
+    description:
+      'Where to return the user once the Plex web-auth flow completes. Must be a trakt-owned destination (`trakt://…`, `http(s)://localhost`, or `https://*.trakt.tv`); the flow appends `?plex_status=connected|error`.',
+  }),
+});

--- a/projects/api/src/contracts/users/schema/request/plexServerParamsSchema.ts
+++ b/projects/api/src/contracts/users/schema/request/plexServerParamsSchema.ts
@@ -1,0 +1,7 @@
+import { z } from '../../../_internal/z.ts';
+
+export const plexServerParamsSchema = z.object({
+  server_id: z.string().openapi({
+    description: 'The Plex server machine identifier.',
+  }),
+});

--- a/projects/api/src/contracts/users/schema/request/plexSettingsUpdateSchema.ts
+++ b/projects/api/src/contracts/users/schema/request/plexSettingsUpdateSchema.ts
@@ -1,0 +1,53 @@
+import { z } from '../../../_internal/z.ts';
+import {
+  plexLibrarySelectionSchema,
+  scrobblerEpisodeTogglesSchema,
+  scrobblerMovieTogglesSchema,
+  scrobblerSeasonTogglesSchema,
+  scrobblerShowTogglesSchema,
+  syncEpisodeTogglesSchema,
+  syncMovieTogglesSchema,
+  syncSeasonTogglesSchema,
+  syncShowTogglesSchema,
+} from '../response/plexSettingsResponseSchema.ts';
+
+// Mirrors the GET shape so it round-trips. Every key is optional and omitted
+// toggle keys are left unchanged server-side (no clobbering), so each toggle
+// group is a partial of its response counterpart.
+export const plexSettingsUpdateSchema = z.object({
+  sync: z.object({
+    selection: z.object({
+      server_ids: z.string().array().optional(),
+      library_ids: plexLibrarySelectionSchema.array().optional(),
+      user_ids: z.string().array().optional(),
+    }).optional(),
+    toggles: z.object({
+      movie: syncMovieTogglesSchema.partial().optional(),
+      show: syncShowTogglesSchema.partial().optional(),
+      season: syncSeasonTogglesSchema.partial().optional(),
+      episode: syncEpisodeTogglesSchema.partial().optional(),
+    }).optional(),
+  }).optional(),
+  scrobbler: z.object({
+    toggles: z.object({
+      movie: scrobblerMovieTogglesSchema.partial().optional(),
+      show: scrobblerShowTogglesSchema.partial().optional(),
+      season: scrobblerSeasonTogglesSchema.partial().optional(),
+      episode: scrobblerEpisodeTogglesSchema.partial().optional(),
+    }).optional(),
+  }).optional(),
+  webhook: z.object({
+    home_users: z.string().nullable().openapi({
+      description: 'Comma-separated Plex home usernames to scrobble for.',
+    }),
+  }).partial().optional(),
+  trigger_sync: z.object({
+    watched_all_data: z.boolean(),
+    collection_all_data: z.boolean(),
+    ratings_all_data: z.boolean(),
+    watchlist_all_data: z.boolean(),
+  }).partial().optional().openapi({
+    description:
+      'Optional. Only this block touches sync timestamps/enqueues work: any `*_all_data: true` resets the affected cursors and enqueues a full sync per selected server; present-but-all-false seeds every cursor to "now" (first sync skips old history); absent writes settings without syncing.',
+  }),
+});

--- a/projects/api/src/contracts/users/schema/request/plexSyncRequestSchema.ts
+++ b/projects/api/src/contracts/users/schema/request/plexSyncRequestSchema.ts
@@ -1,0 +1,12 @@
+import { z } from '../../../_internal/z.ts';
+
+export const plexSyncRequestSchema = z.object({
+  server_id: z.string().optional().openapi({
+    description:
+      'Sync this server; omit to sync every server in the saved selection.',
+  }),
+  all_data: z.boolean().optional().openapi({
+    description:
+      'When true, re-pulls full history; otherwise an incremental sync.',
+  }),
+});

--- a/projects/api/src/contracts/users/schema/response/plexConnectResponseSchema.ts
+++ b/projects/api/src/contracts/users/schema/response/plexConnectResponseSchema.ts
@@ -1,0 +1,7 @@
+import { z } from '../../../_internal/z.ts';
+
+export const plexConnectResponseSchema = z.object({
+  url: z.string().openapi({
+    description: 'The Plex web-auth URL for the client to open.',
+  }),
+});

--- a/projects/api/src/contracts/users/schema/response/plexErrorResponseSchema.ts
+++ b/projects/api/src/contracts/users/schema/response/plexErrorResponseSchema.ts
@@ -1,0 +1,10 @@
+import { z } from '../../../_internal/z.ts';
+
+export const plexErrorResponseSchema = z.object({
+  error_code: z.string().openapi({
+    description:
+      'Machine-readable error code (e.g. `bad_auth`, `invalid_server_url`, `plex_timeout`).',
+  }),
+  message: z.string(),
+  guidance: z.string(),
+});

--- a/projects/api/src/contracts/users/schema/response/plexServerAccountsResponseSchema.ts
+++ b/projects/api/src/contracts/users/schema/response/plexServerAccountsResponseSchema.ts
@@ -1,0 +1,28 @@
+import { z } from '../../../_internal/z.ts';
+
+export const plexAccountSchema = z.object({
+  id: z.number().int(),
+  name: z.string(),
+});
+
+export const plexLibrarySchema = z.object({
+  id: z.number().int(),
+  uuid: z.string(),
+  type: z.string(),
+  title: z.string(),
+  agent: z.string(),
+  scanner: z.string(),
+  selected: z.boolean().openapi({
+    description:
+      "Whether this library is in the user's current sync selection.",
+  }),
+  url: z.string(),
+});
+
+export const plexServerAccountsResponseSchema = z.object({
+  accounts: plexAccountSchema.array().openapi({
+    description:
+      'Home accounts on the server; empty for servers the user does not own.',
+  }),
+  libraries: plexLibrarySchema.array(),
+});

--- a/projects/api/src/contracts/users/schema/response/plexServersResponseSchema.ts
+++ b/projects/api/src/contracts/users/schema/response/plexServersResponseSchema.ts
@@ -1,0 +1,21 @@
+import { z } from '../../../_internal/z.ts';
+
+export const plexServerSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  connection_count: z.number().int(),
+  connection_timeout: z.number().int().openapi({
+    description:
+      'Worst-case probe timeout across the server connections, in seconds.',
+  }),
+  ports: z.number().int().array(),
+  owned: z.boolean(),
+  url: z.string().nullable().openapi({
+    description:
+      'The resolved remote URL, or null when the server is unreachable.',
+  }),
+});
+
+export const plexServersResponseSchema = z.object({
+  servers: plexServerSchema.array(),
+});

--- a/projects/api/src/contracts/users/schema/response/plexSettingsResponseSchema.ts
+++ b/projects/api/src/contracts/users/schema/response/plexSettingsResponseSchema.ts
@@ -1,0 +1,114 @@
+import { z } from '../../../_internal/z.ts';
+
+export const plexLibrarySelectionSchema = z.object({
+  server_id: z.string(),
+  uuid: z.string(),
+});
+
+export const syncMovieTogglesSchema = z.object({
+  watching: z.boolean(),
+  watched: z.boolean(),
+  rated: z.boolean(),
+  collected: z.boolean(),
+  watchlist: z.boolean(),
+});
+
+export const syncShowTogglesSchema = z.object({
+  rated: z.boolean(),
+  watchlist: z.boolean(),
+});
+
+export const syncSeasonTogglesSchema = z.object({
+  rated: z.boolean(),
+});
+
+export const syncEpisodeTogglesSchema = z.object({
+  watching: z.boolean(),
+  watched: z.boolean(),
+  rated: z.boolean(),
+  collected: z.boolean(),
+});
+
+export const scrobblerMovieTogglesSchema = z.object({
+  watching: z.boolean(),
+  watched: z.boolean(),
+  rated: z.boolean(),
+  collected: z.boolean(),
+});
+
+export const scrobblerShowTogglesSchema = z.object({
+  rated: z.boolean(),
+});
+
+export const scrobblerSeasonTogglesSchema = z.object({
+  rated: z.boolean(),
+});
+
+export const scrobblerEpisodeTogglesSchema = z.object({
+  watching: z.boolean(),
+  watched: z.boolean(),
+  rated: z.boolean(),
+  collected: z.boolean(),
+});
+
+export const plexSyncTogglesSchema = z.object({
+  movie: syncMovieTogglesSchema,
+  show: syncShowTogglesSchema,
+  season: syncSeasonTogglesSchema,
+  episode: syncEpisodeTogglesSchema,
+});
+
+export const plexScrobblerTogglesSchema = z.object({
+  movie: scrobblerMovieTogglesSchema,
+  show: scrobblerShowTogglesSchema,
+  season: scrobblerSeasonTogglesSchema,
+  episode: scrobblerEpisodeTogglesSchema,
+});
+
+export const plexSettingsResponseSchema = z.object({
+  connection: z.object({
+    connected: z.boolean().openapi({
+      description: 'Whether a Plex authorization exists.',
+    }),
+    username: z.string().nullable().openapi({
+      description: 'The stored Plex uid (currently usually null).',
+    }),
+  }),
+  webhook: z.object({
+    url: z.string().nullable().openapi({
+      description:
+        'The real-time scrobbler webhook URL; null unless the user is VIP.',
+    }),
+    last_event_at: z.string().datetime().nullable().openapi({
+      description:
+        'When the webhook last fired, normalized to `.000Z`, or null.',
+    }),
+    event_count: z.number().int(),
+    home_users: z.string().nullable().openapi({
+      description: 'Comma-separated Plex home usernames to scrobble for.',
+    }),
+  }),
+  sync: z.object({
+    configured: z.boolean().openapi({
+      description: 'Whether the initial sync has been set up.',
+    }),
+    error: z.boolean().openapi({
+      description: 'Whether a persisted Plex-sync error is currently active.',
+    }),
+    selection: z.object({
+      server_ids: z.string().array(),
+      library_ids: plexLibrarySelectionSchema.array(),
+      user_ids: z.string().array(),
+    }),
+    toggles: plexSyncTogglesSchema.openapi({
+      description:
+        'Batch-sync toggles (unset ⇒ false). Includes `watching`/`watchlist`.',
+    }),
+  }),
+  scrobbler: z.object({
+    toggles: plexScrobblerTogglesSchema.openapi({
+      description:
+        'Real-time scrobbler toggles (unset ⇒ false). No `watchlist`.',
+    }),
+  }),
+});


### PR DESCRIPTION
> [!IMPORTANT]
> **TODO before merge**
> - [ ] Merge in https://github.com/trakt/trakt-api/pull/807 before this PR so the version gets updated in succession.

# Description

Wires the newly-merged **Plex sync management** endpoints into the `@trakt/api` ts-rest contracts, so native clients can port the web `/settings/plex` ("Plex Scrobbler" / "Plex Sync") page.

Covers both halves of that page — **Plex Sync** (hourly batch pull: `plex_sync_*` toggles + server/library/home-user selection) and **Plex Webhook/Scrobbler** (real-time: `plex_*` toggles + webhook URL + home users). All routes require an official Trakt app API key **and** a user OAuth token; VIP is not enforced at the API (read endpoints stay open so the client can render state).

These all live under `/users/settings/plex`, so they're a collection-level sub-router on the existing `users` contract (alongside `syncs`) — **no new top-level contract**, and `traktContract.ts` / `src/index.ts` need no changes since `users` is already registered and exported.

> The data-syncs history table is already covered by the generic endpoints from #803 (`GET /users/syncs[/:type|/:id]`, `/:id/paused|skipped`, `DELETE /users/syncs/:id`) — not repeated here.

## New `plex` sub-router on the `users` contract (`pathPrefix: '/settings/plex'`)

| Route | Method & Path | Response |
|---|---|---|
| `settings` | `GET /users/settings/plex` | `200` → `plexSettingsResponseSchema` |
| `updateSettings` | `PUT /users/settings/plex` | `204` |
| `connect` | `POST /users/settings/plex/connect` | `200` → `{ url }`; `400` |
| `disconnect` | `DELETE /users/settings/plex/connect` | `204` |
| `servers` | `GET /users/settings/plex/servers` | `200` → `{ servers[] }`; `401` `502` `504` |
| `serverAccounts` | `GET /users/settings/plex/servers/:server_id` | `200` → `{ accounts[], libraries[] }`; `401` `404` `422` `502` `503` `504` |
| `sync` | `POST /users/settings/plex/sync` | `201`; `422` |

- **`settings`** returns connection status, the (VIP-only) scrobbler webhook info, server/library/home-user selection, and both toggle sets. `connection.connected` reflects that a Plex authorization exists; for a live auth check, call `servers` and watch for `bad_auth`. `webhook.url` is null unless VIP. `sync.configured` gates the "start fresh / import all" UI. Toggles are booleans (unset ⇒ `false`); sync toggles include `watching`/`watchlist`, scrobbler toggles don't carry `watchlist`.
- **`updateSettings`** mirrors the GET shape so it round-trips. Every key is optional and omitted toggle keys are left unchanged (no clobbering), so each toggle group is modeled as a deep-partial of its response counterpart. `library_ids` is sent structured (`{ server_id, uuid }`) and rebuilt into the `server|uuid` storage server-side. The optional **`trigger_sync`** block (`watched_all_data` / `collection_all_data` / `ratings_all_data` / `watchlist_all_data`) is the only thing that touches sync timestamps or enqueues work.
- **`connect`** mints a Plex PIN-OAuth web-auth URL; `return_url` is validated against the trakt-owned allowlist (`trakt://`, `http(s)://localhost`, `https://*.trakt.tv`) → `400` otherwise. The website-only redirect target that completes the flow (`GET /plex/auth/return/app`) is intentionally **not** in the contract — it's internal and not called by clients.
- **`servers` / `serverAccounts`** are network-bound (probe each server) and return a shared `{ error_code, message, guidance }` envelope (`plexErrorResponseSchema`) on Plex/auth failures; the description maps each `error_code` (`bad_auth`, `invalid_server_url`, `plex_timeout`, …) to its HTTP status.

## Schemas (one per file under `users/schema/{request,response}`, `*Schema.ts`)

- **Response:** `plexSettingsResponseSchema` (+ exported toggle/selection building blocks reused by the update request), `plexServersResponseSchema` / `plexServerSchema`, `plexServerAccountsResponseSchema` / `plexAccountSchema` / `plexLibrarySchema`, `plexConnectResponseSchema`, `plexErrorResponseSchema`.
- **Request:** `plexSettingsUpdateSchema`, `plexConnectRequestSchema`, `plexServerParamsSchema`, `plexSyncRequestSchema`.
- Shapes match the Rails source exactly: server `id` is a string, library/account `id` are ints, `connection_timeout` is seconds, `ports` is `int[]`, toggles are always-present booleans in the response but partial in the request, timestamps documented as `.000Z`.

## Conventions

Placed alongside the existing inline `GLOBAL_LEVEL` / `ENTITY_LEVEL` / `syncs` routers in `users/index.ts`; `authMetadata('required')` inherited from the parent `users` router; `#### 🔒 OAuth Required` descriptions; `z.infer` type aliases + schema re-exports; `400`/`422` error responses use `z.undefined()` to match the repo-wide norm, while the documented Plex error envelope uses a real schema. Bumped `@trakt/api` to `0.4.15`.

# Testing

- `deno check src/index.ts` — passes.
- `deno lint` + `deno fmt --check` — clean on all new files.
- OpenAPI `generate` + `validate` — pass; all 7 operations and their response codes confirmed in the generated spec:

| Method | Path | Responses |
|---|---|---|
| `GET` | `/users/settings/plex/` | `200` |
| `PUT` | `/users/settings/plex/` | `204` |
| `POST` | `/users/settings/plex/connect` | `200`, `400` |
| `DELETE` | `/users/settings/plex/connect` | `204` |
| `GET` | `/users/settings/plex/servers` | `200`, `401`, `502`, `504` |
| `GET` | `/users/settings/plex/servers/{server_id}` | `200`, `401`, `404`, `422`, `502`, `503`, `504` |
| `POST` | `/users/settings/plex/sync` | `201`, `422` |

> Note: the lone `deno fmt` miss is a pre-existing missing trailing newline in `projects/api/deno.json` (present on `master`), unrelated to this change.

# Checklist

- [x] Clear and concise title
- [x] Detailed description
- [x] Coding standards (`deno fmt` / `deno lint` clean)
- [x] Documentation (OpenAPI regenerated & validated)
- [ ] Tests — no new contract tests added (consistent with #803 and existing contract additions)
