### PR TITLE
YIR: adds more data needed for native yir

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -57,6 +57,7 @@ module.exports = {
         'team',
         'user',
         'watchnow',
+        'yir',
         'younify',
       ],
     ],

--- a/projects/api/deno.json
+++ b/projects/api/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@trakt/api",
   "exports": "./src/index.ts",
-  "version": "0.4.14",
+  "version": "0.4.15",
   "imports": {
     "@anatine/zod-openapi": "npm:@anatine/zod-openapi@^2.2.6",
     "@std/testing": "jsr:@std/testing@^1.0.5",

--- a/projects/api/src/contracts/users/schema/response/monthInReviewResponseSchema.ts
+++ b/projects/api/src/contracts/users/schema/response/monthInReviewResponseSchema.ts
@@ -1,5 +1,9 @@
 import { typedEpisodeResponseSchema } from '../../../_internal/response/episodeResponseSchema.ts';
-import { typedMovieResponseSchema } from '../../../_internal/response/movieResponseSchema.ts';
+import {
+  movieResponseSchema,
+  typedMovieResponseSchema,
+} from '../../../_internal/response/movieResponseSchema.ts';
+import { showResponseSchema } from '../../../_internal/response/showResponseSchema.ts';
 import { z } from '../../../_internal/z.ts';
 
 const statsSchema = z.object({
@@ -31,7 +35,66 @@ const watchedItemSchema = z.discriminatedUnion('type', [
   watchedMovieSchema,
 ]);
 
-export const monthInReviewResponseSchema = z.object({
+// countries: watched shows/movies grouped by production country, sorted by
+// count desc.
+const countryCountSchema = z.object({
+  country_count: z.number().int(),
+  countries: z.object({
+    country: z.string(),
+    count: z.number().int(),
+  }).array(),
+});
+
+const countriesSchema = z.object({
+  shows: countryCountSchema,
+  movies: countryCountSchema,
+});
+
+// trends: most-watched titles premiering each month. `watchers` is the global
+// play count, `watched` is whether this user watched it.
+const trendShowSchema = z.object({
+  month: z.number().int(),
+  month_name: z.string(),
+  watchers: z.number().int(),
+  watched: z.boolean(),
+  show: showResponseSchema,
+});
+
+const trendMovieSchema = z.object({
+  month: z.number().int(),
+  month_name: z.string(),
+  watchers: z.number().int(),
+  watched: z.boolean(),
+  movie: movieResponseSchema,
+});
+
+const trendsSchema = z.object({
+  shows: trendShowSchema.array(),
+  movies: trendMovieSchema.array(),
+});
+
+// thanks: popular titles the user hasn't watched yet.
+const thanksSchema = z.object({
+  shows: z.object({ show: showResponseSchema }).array(),
+  movies: z.object({ movie: movieResponseSchema }).array(),
+});
+
+// streaming_services: subscription services the user watched on, with per-type
+// counts. Month in Review only.
+const streamingServicesSchema = z.object({
+  country: z.string(),
+  services: z.object({
+    source: z.string(),
+    name: z.string(),
+    shows: z.number().int(),
+    movies: z.number().int(),
+    all: z.number().int(),
+  }).array(),
+});
+
+// Shared by both the month- and year-in-review endpoints. Year in Review does
+// not include `streaming_services` (the catalog scan is bounded to a month).
+export const reviewBaseSchema = z.object({
   stats: z.object({
     all: statsCategoriesSchema.merge(z.object({
       lists_counts: statsSchema,
@@ -45,4 +108,11 @@ export const monthInReviewResponseSchema = z.object({
   }),
   first_watched: watchedItemSchema.nullable(),
   last_watched: watchedItemSchema.nullable(),
+  countries: countriesSchema,
+  trends: trendsSchema,
+  thanks: thanksSchema,
 });
+
+export const monthInReviewResponseSchema = reviewBaseSchema.merge(z.object({
+  streaming_services: streamingServicesSchema,
+}));

--- a/projects/api/src/contracts/users/schema/response/yearInReviewResponseSchema.ts
+++ b/projects/api/src/contracts/users/schema/response/yearInReviewResponseSchema.ts
@@ -1,3 +1,5 @@
-import { monthInReviewResponseSchema } from './monthInReviewResponseSchema.ts';
+import { reviewBaseSchema } from './monthInReviewResponseSchema.ts';
 
-export const yearInReviewResponseSchema = monthInReviewResponseSchema;
+// Year in Review returns the same shape as Month in Review minus
+// `streaming_services` (that catalog scan is bounded to a single month).
+export const yearInReviewResponseSchema = reviewBaseSchema;


### PR DESCRIPTION
# Description

Wires the newly-merged **Year in Review / Month in Review** data expansion into the `@trakt/api` ts-rest contracts.

Same endpoints (`GET /users/:id/yir/:year` and `GET /users/:id/mir/:year/:month`), but the API now surfaces four sections that already existed in the web experience and weren't exposed over the API. The contract's `yearInReviewResponseSchema` was aliased to `monthInReviewResponseSchema`, which only modeled `stats` / `images` / `first_watched` / `last_watched` — so typed clients would never see the new data. This adds them.

## New sections

| Section | Endpoints | Shape |
|---|---|---|
| `countries` | YIR + MIR | per type (`shows`/`movies`): `country_count` + `countries[]` of `{ country, count }` |
| `trends` | YIR + MIR | per type: up to 12 entries of `{ month, month_name, watchers, watched, show \| movie }` |
| `thanks` | YIR + MIR | per type: array of `{ show }` / `{ movie }` (popular titles the user hasn't watched) |
| `streaming_services` | **MIR only** | `{ country, services[] }` with per-service `{ source, name, shows, movies, all }` |

- `trends.watchers` is the global play count; `trends.watched` is whether *this* user watched it.
- `trends`/`thanks` elements carry a nested `show`/`movie` media object with **no `type` discriminator** (the `type` field is only emitted for `first_watched`/`last_watched`), so they wrap `showResponseSchema` / `movieResponseSchema` directly rather than the `typed*` variants.
- `streaming_services` is Month-in-Review only — its catalog scan is bounded to a single month — so it must not appear on the Year in Review shape.

## Implementation

- [monthInReviewResponseSchema.ts](projects/api/src/contracts/users/schema/response/monthInReviewResponseSchema.ts): added `countries`, `trends`, `thanks`, `streaming_services`. Split out an exported `reviewBaseSchema` (shared fields + `countries`/`trends`/`thanks`); `monthInReviewResponseSchema = reviewBaseSchema + streaming_services`.
- [yearInReviewResponseSchema.ts](projects/api/src/contracts/users/schema/response/yearInReviewResponseSchema.ts): now `= reviewBaseSchema` (drops the previous plain alias so it excludes `streaming_services`).
- New section schemas kept inline as private helpers, matching the file's existing convention (`statsSchema`, `watchedItemSchema`, …).
- No route, `traktContract.ts`, or `src/index.ts` changes — the existing `MonthInReviewResponse` / `YearInReviewResponse` type aliases pick up the new fields automatically.
- Bumped `@trakt/api` to `0.4.15`.

# Testing

- `deno check src/index.ts` — passes.
- `deno lint` + `deno fmt --check` — clean.
- OpenAPI `generate` + `validate` — pass; the generated spec confirms the per-endpoint shapes:

| Endpoint | 200 properties |
|---|---|
| `GET /users/{id}/mir/{year}/{month}` | `stats, images, first_watched, last_watched, countries, trends, thanks, streaming_services` |
| `GET /users/{id}/yir/{year}` | `stats, images, first_watched, last_watched, countries, trends, thanks` |

# Checklist

- [x] Clear and concise title
- [x] Detailed description
- [x] Coding standards (`deno fmt` / `deno lint` clean)
- [x] Documentation (OpenAPI regenerated & validated)
- [ ] Tests — no new contract tests added (consistent with prior contract additions)
