### PR TITLE
Media: add refresh methods for movies, shows & people

### DIFF
--- a/projects/api/deno.json
+++ b/projects/api/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@trakt/api",
   "exports": "./src/index.ts",
-  "version": "0.4.16",
+  "version": "0.4.17",
   "imports": {
     "@anatine/zod-openapi": "npm:@anatine/zod-openapi@^2.2.6",
     "@std/testing": "jsr:@std/testing@^1.0.5",

--- a/projects/api/src/contracts/_internal/request/refreshQuerySchema.ts
+++ b/projects/api/src/contracts/_internal/request/refreshQuerySchema.ts
@@ -1,0 +1,7 @@
+import { z } from '../z.ts';
+
+export const refreshQuerySchema = z.object({
+  images: z.boolean().nullish().openapi({
+    description: 'Also queue a refresh of the resource images.',
+  }),
+});

--- a/projects/api/src/contracts/movies/index.ts
+++ b/projects/api/src/contracts/movies/index.ts
@@ -15,6 +15,7 @@ import { mediaReportRequestSchema } from '../_internal/request/mediaReportReques
 import { pageQuerySchema } from '../_internal/request/pageQuerySchema.ts';
 import { periodParamsSchema } from '../_internal/request/periodParamsSchema.ts';
 import { recentPeriodParamsSchema } from '../_internal/request/recentPeriodParamsSchema.ts';
+import { refreshQuerySchema } from '../_internal/request/refreshQuerySchema.ts';
 import { commentResponseSchema } from '../_internal/response/commentResponseSchema.ts';
 import type { genreEnumSchema } from '../_internal/response/genreEnumSchema.ts';
 import { justWatchLinkResponseSchema } from '../_internal/response/justWatchLinkResponseSchema.ts';
@@ -155,6 +156,18 @@ Returns streaming and watch now sources for a movie in the requested country. Us
         200: justWatchLinkResponseSchema,
       },
     },
+    refresh: {
+      summary: 'Refresh movie JustWatch links',
+      description: `#### 🔥 VIP Only 🔒 OAuth Required
+Queue a refresh of a movie's JustWatch watch now links.`,
+      path: '/refresh/justwatch',
+      method: 'PUT',
+      pathParams: idParamsSchema,
+      body: z.undefined(),
+      responses: {
+        201: z.undefined(),
+      },
+    },
   }),
   people: {
     summary: 'Get all people for a movie',
@@ -251,6 +264,19 @@ Report a movie for moderator review. Send a \`reason\` and optional \`message\` 
       201: z.undefined(),
       400: z.undefined(),
       409: z.undefined(),
+    },
+  },
+  refresh: {
+    summary: 'Refresh movie metadata',
+    description: `#### 🔥 VIP Only 🔒 OAuth Required
+Queue a full metadata refresh for a movie. Pass \`images=true\` to also refresh the movie's images.`,
+    path: '/refresh',
+    method: 'PUT',
+    query: refreshQuerySchema,
+    pathParams: idParamsSchema,
+    body: z.undefined(),
+    responses: {
+      201: z.undefined(),
     },
   },
 }, {

--- a/projects/api/src/contracts/people/index.ts
+++ b/projects/api/src/contracts/people/index.ts
@@ -2,6 +2,7 @@ import { builder } from '../_internal/builder.ts';
 import { extendedMediaQuerySchema } from '../_internal/request/extendedMediaQuerySchema.ts';
 import { extendedPeopleQuerySchema } from '../_internal/request/extendedPeopleQuerySchema.ts';
 import { idParamsSchema } from '../_internal/request/idParamsSchema.ts';
+import { refreshQuerySchema } from '../_internal/request/refreshQuerySchema.ts';
 import { z } from '../_internal/z.ts';
 import { peopleReportRequestSchema } from './schema/request/peopleReportRequestSchema.ts';
 import { peopleMovieCreditsResponseSchema } from './schema/response/peopleMovieCreditsResponseSchema.ts';
@@ -79,6 +80,19 @@ Report a person for moderator review. Send a \`reason\` and optional \`message\`
       201: z.undefined(),
       400: z.undefined(),
       409: z.undefined(),
+    },
+  },
+  refresh: {
+    summary: 'Refresh person metadata',
+    description: `#### 🔥 VIP Only 🔒 OAuth Required
+Queue a full metadata refresh for a person. Pass \`images=true\` to also refresh the person's images.`,
+    path: '/refresh',
+    method: 'PUT',
+    query: refreshQuerySchema,
+    pathParams: idParamsSchema,
+    body: z.undefined(),
+    responses: {
+      201: z.undefined(),
     },
   },
 }, {

--- a/projects/api/src/contracts/shows/index.ts
+++ b/projects/api/src/contracts/shows/index.ts
@@ -15,6 +15,7 @@ import { mediaReportRequestSchema } from '../_internal/request/mediaReportReques
 import { pageQuerySchema } from '../_internal/request/pageQuerySchema.ts';
 import { periodParamsSchema } from '../_internal/request/periodParamsSchema.ts';
 import { recentPeriodParamsSchema } from '../_internal/request/recentPeriodParamsSchema.ts';
+import { refreshQuerySchema } from '../_internal/request/refreshQuerySchema.ts';
 import { statsQuerySchema } from '../_internal/request/statsQuerySchema.ts';
 import { commentResponseSchema } from '../_internal/response/commentResponseSchema.ts';
 import { episodeResponseSchema } from '../_internal/response/episodeResponseSchema.ts';
@@ -348,6 +349,18 @@ Returns streaming and watch now sources for a show in the requested country. Use
         200: justWatchLinkResponseSchema,
       },
     },
+    refresh: {
+      summary: 'Refresh show JustWatch links',
+      description: `#### 🔥 VIP Only 🔒 OAuth Required
+Queue a refresh of a show's JustWatch watch now links.`,
+      path: '/refresh/justwatch',
+      method: 'PUT',
+      pathParams: idParamsSchema,
+      body: z.undefined(),
+      responses: {
+        201: z.undefined(),
+      },
+    },
   }),
   people: {
     summary: 'Get all people for a show',
@@ -544,6 +557,19 @@ Report a show for moderator review. Send a \`reason\` and optional \`message\` w
       201: z.undefined(),
       400: z.undefined(),
       409: z.undefined(),
+    },
+  },
+  refresh: {
+    summary: 'Refresh show metadata',
+    description: `#### 🔥 VIP Only 🔒 OAuth Required
+Queue a full metadata refresh for a show. Pass \`images=true\` to also refresh the show's images.`,
+    path: '/refresh',
+    method: 'PUT',
+    query: refreshQuerySchema,
+    pathParams: idParamsSchema,
+    body: z.undefined(),
+    responses: {
+      201: z.undefined(),
     },
   },
   episode: EPISODE_LEVEL,


### PR DESCRIPTION
# Overview

Adds VIP metadata/artwork refresh endpoints to the `movies`, `shows`, and `people` contracts, plus the JustWatch link refresh for `movies` and `shows`. All paths map to existing API routes — no backend changes required.

# New methods

| Client method | Request | Refreshes |
|---|---|---|
| `movies.refresh` | `PUT /movies/:id/refresh` | Movie metadata (add `?images=true` to also refresh images) |
| `movies.justwatch.refresh` | `PUT /movies/:id/refresh/justwatch` | Movie JustWatch watch-now links |
| `shows.refresh` | `PUT /shows/:id/refresh` | Show metadata (add `?images=true` to also refresh images) |
| `shows.justwatch.refresh` | `PUT /shows/:id/refresh/justwatch` | Show JustWatch watch-now links |
| `people.refresh` | `PUT /people/:id/refresh` | Person metadata (add `?images=true` to also refresh images) |

All five are `PUT`, require **🔥 VIP + 🔒 OAuth**, and return **`201`** with no body once the refresh is queued.

# Usage

```ts
// Metadata only
await api.movies.refresh({ params: { id: 'tron-legacy-2010' } });

// Metadata + images
await api.movies.refresh({
  params: { id: 'tron-legacy-2010' },
  query: { images: true },
});

// JustWatch links
await api.movies.justwatch.refresh({ params: { id: 'tron-legacy-2010' } });

// Shows — same shape
await api.shows.refresh({ params: { id: 'game-of-thrones' }, query: { images: true } });
await api.shows.justwatch.refresh({ params: { id: 'game-of-thrones' } });

// People (no JustWatch)
await api.people.refresh({ params: { id: 'bryan-cranston' }, query: { images: true } });

// 201 = queued, body is empty
const { status } = await api.shows.refresh({ params: { id: 'severance' } });
```

# Notes

- **`images` as a query param.** A single `refresh` method handles both metadata-only and metadata+images via the optional `images` flag, so there's no separate images endpoint.
- The JustWatch refresh lives at `/refresh/justwatch`, nested alongside the existing `justwatch.link` GET.
- Shared `refreshQuerySchema` (`images: boolean`) added under `_internal/request/` and reused by all three contracts.

# Verification

- `deno fmt` / `deno lint` — clean
- `deno check` (movies, shows, people) — passes
- `deno task openapi:validate` — passes (exit 0); all five paths generate as expected
