### PR TITLE
Media: refresh methods use POST

### DIFF
--- a/projects/api/src/contracts/movies/index.ts
+++ b/projects/api/src/contracts/movies/index.ts
@@ -161,7 +161,7 @@ Returns streaming and watch now sources for a movie in the requested country. Us
       description: `#### 🔥 VIP Only 🔒 OAuth Required
 Queue a refresh of a movie's JustWatch watch now links.`,
       path: '/refresh/justwatch',
-      method: 'PUT',
+      method: 'POST',
       pathParams: idParamsSchema,
       body: z.undefined(),
       responses: {
@@ -271,7 +271,7 @@ Report a movie for moderator review. Send a \`reason\` and optional \`message\` 
     description: `#### 🔥 VIP Only 🔒 OAuth Required
 Queue a full metadata refresh for a movie. Pass \`images=true\` to also refresh the movie's images.`,
     path: '/refresh',
-    method: 'PUT',
+    method: 'POST',
     query: refreshQuerySchema,
     pathParams: idParamsSchema,
     body: z.undefined(),

--- a/projects/api/src/contracts/people/index.ts
+++ b/projects/api/src/contracts/people/index.ts
@@ -87,7 +87,7 @@ Report a person for moderator review. Send a \`reason\` and optional \`message\`
     description: `#### 🔥 VIP Only 🔒 OAuth Required
 Queue a full metadata refresh for a person. Pass \`images=true\` to also refresh the person's images.`,
     path: '/refresh',
-    method: 'PUT',
+    method: 'POST',
     query: refreshQuerySchema,
     pathParams: idParamsSchema,
     body: z.undefined(),

--- a/projects/api/src/contracts/shows/index.ts
+++ b/projects/api/src/contracts/shows/index.ts
@@ -354,7 +354,7 @@ Returns streaming and watch now sources for a show in the requested country. Use
       description: `#### 🔥 VIP Only 🔒 OAuth Required
 Queue a refresh of a show's JustWatch watch now links.`,
       path: '/refresh/justwatch',
-      method: 'PUT',
+      method: 'POST',
       pathParams: idParamsSchema,
       body: z.undefined(),
       responses: {
@@ -564,7 +564,7 @@ Report a show for moderator review. Send a \`reason\` and optional \`message\` w
     description: `#### 🔥 VIP Only 🔒 OAuth Required
 Queue a full metadata refresh for a show. Pass \`images=true\` to also refresh the show's images.`,
     path: '/refresh',
-    method: 'PUT',
+    method: 'POST',
     query: refreshQuerySchema,
     pathParams: idParamsSchema,
     body: z.undefined(),


### PR DESCRIPTION
> [!IMPORTANT]
> This fixes a bug with PR https://github.com/trakt/trakt-api/pull/809 and uses the correct `POST` methods.

Adds VIP metadata/artwork refresh endpoints to the `movies`, `shows`, and `people` contracts, plus the JustWatch link refresh for `movies` and `shows`. All paths map to existing API routes — no backend changes required.

# New methods

| Client method | Request | Refreshes |
|---|---|---|
| `movies.refresh` | `POST /movies/:id/refresh` | Movie metadata (add `?images=true` to also refresh images) |
| `movies.justwatch.refresh` | `POST /movies/:id/refresh/justwatch` | Movie JustWatch watch-now links |
| `shows.refresh` | `POST /shows/:id/refresh` | Show metadata (add `?images=true` to also refresh images) |
| `shows.justwatch.refresh` | `POST /shows/:id/refresh/justwatch` | Show JustWatch watch-now links |
| `people.refresh` | `POST /people/:id/refresh` | Person metadata (add `?images=true` to also refresh images) |

All five are `POST`, require **🔥 VIP + 🔒 OAuth**, and return **`201`** with no body once the refresh is queued.

# Usage

```ts
// Metadata only
await api.movies.refresh({ params: { id: 'tron-legacy-2010' } });

// Metadata + images
await api.movies.refresh({
  params: { id: 'tron-legacy-2010' },
  query: { images: true },
});

// JustWatch links
await api.movies.justwatch.refresh({ params: { id: 'tron-legacy-2010' } });

// Shows — same shape
await api.shows.refresh({ params: { id: 'game-of-thrones' }, query: { images: true } });
await api.shows.justwatch.refresh({ params: { id: 'game-of-thrones' } });

// People (no JustWatch)
await api.people.refresh({ params: { id: 'bryan-cranston' }, query: { images: true } });

// 201 = queued, body is empty
const { status } = await api.shows.refresh({ params: { id: 'severance' } });
```

# Notes

- **`images` as a query param.** A single `refresh` method handles both metadata-only and metadata+images via the optional `images` flag, so there's no separate images endpoint.
- The JustWatch refresh lives at `/refresh/justwatch`, nested alongside the existing `justwatch.link` GET.
- Shared `refreshQuerySchema` (`images: boolean`) added under `_internal/request/` and reused by all three contracts.

# Verification

- `deno fmt` / `deno lint` — clean
- `deno check` (movies, shows, people) — passes
- `deno task openapi:validate` — passes (exit 0); all five paths generate as expected
