### PR TITLE
fix(contracts): widen asString return type to string

### DIFF
--- a/projects/api/src/contracts/_internal/z.ts
+++ b/projects/api/src/contracts/_internal/z.ts
@@ -33,9 +33,14 @@ export function int64(schema: z.ZodNumber) {
  */
 export function asString<T extends z.ZodEnum<[string, ...string[]]>>(
   schema: T,
-) {
-  // Use type assertion to access the openapi method
-  return (schema as T & { openapi: (meta: unknown) => T })
+): z.ZodString {
+  // The inferred output must stay `string`, not the literal union: consumers
+  // bind their own zod for the @anatine/zod-openapi peer, and under zod 4 the
+  // enum would otherwise leak as a literal union and break assignments from
+  // plain string data. Runtime keeps validating enum membership.
+  return (schema as unknown as z.ZodString & {
+    openapi: (meta: unknown) => z.ZodString;
+  })
     .openapi({
       type: 'string',
       enum: undefined,


### PR DESCRIPTION
## Problem

`asString` is meant to "force a schema to be treated as a string" (it sets `type: 'string'`, `enum: undefined` in the OpenAPI metadata). But it returned the `ZodEnum` unchanged at the type level, so `z.infer` of every `asString(z.enum([...]))` schema is the **literal union**, not `string`.

This is invisible inside this package (it builds on zod 3), but it breaks consumers. `@anatine/zod-openapi` (peer `zod@^3.20.0`) and `@ts-rest/core` (peer `zod@^3.22.3`) bind to whatever zod the consumer resolves. When a consumer's root zod is 4.x, a lockfile re-resolve binds those peers to zod 4, and under zod 4 the leaked literal union makes plain-string assignments fail to type-check:

```
TS2322: Type 'string' is not assignable to type '"G" | "NC-17" | "NR" | ...'
```

trakt-workers hit this on `certification`, `gender`, `known_for_department`, `category` after bumping to 0.4.17 (the new `refreshQuerySchema` is what drags the `@anatine` augmentation into the movie/show/person contract graph and activates the zod-4 inference). Their current workaround pins the two peers back to `zod@3.25.76` in `deno.lock`, but that pin gets reflipped by any lock regen (including the automated dependency-bump job).

## Fix

Annotate `asString`'s return as `z.ZodString`. The inferred output stays `string` regardless of which zod a consumer binds for the peers, because the return type references this package's own zod. Runtime is unchanged: the underlying `ZodEnum` still validates membership, and the OpenAPI schema still emits `type: string` with no enum.

## Verification

- `deno check src/index.ts` clean.
- `deno task test`: same 5 pre-existing failures as `master` (stale `HistoryRequest` export rename in `HistoryRequest.test.ts`), zero new failures.
- Pointed trakt-workers at this branch's source with the peers force-bound to `zod@4.4.3` (the broken condition): `deno task check` -> **0 errors**. Confirms the fix removes the need for the lockfile pin.

## Follow-up

Once released, trakt-workers can drop the `deno.lock` peer pin (trakt/trakt-workers#978).