### PR TITLE
Add sync last activities contract

### DIFF
--- a/projects/api/src/contracts/sync/index.ts
+++ b/projects/api/src/contracts/sync/index.ts
@@ -32,6 +32,7 @@ import { favoritesRemoveResponseSchema } from './schema/response/favoritesRemove
 import { favoritesResponseSchema } from './schema/response/favoritesResponseSchema.ts';
 import { historyRemoveResponseSchema } from './schema/response/historyRemoveResponseSchema.ts';
 import { historyResponseSchema } from './schema/response/historyResponseSchema.ts';
+import { lastActivitiesResponseSchema } from './schema/response/lastActivitiesResponseSchema.ts';
 import { movieProgressResponseSchema } from './schema/response/movieProgressResponseSchema.ts';
 import { ratingsSyncResponseSchema } from './schema/response/ratingsResponseSchema.ts';
 import { removeRatingsResponseSchema } from './schema/response/removeRatingsResponseSchema.ts';
@@ -420,6 +421,16 @@ Returns the authenticated user episode collection in a minimal format optimized 
 });
 
 export const sync = builder.router({
+  lastActivities: {
+    summary: 'Get last activity',
+    description: `#### 🔒 OAuth Required
+Returns the latest activity timestamps for the authenticated user. Cache these dates locally and compare them before syncing to avoid fetching data that has not changed.`,
+    method: 'GET',
+    path: '/last_activities',
+    responses: {
+      200: lastActivitiesResponseSchema,
+    },
+  },
   history,
   progress,
   watchlist,
@@ -441,6 +452,7 @@ export {
   favoritesResponseSchema,
   historyRemoveRequestSchema,
   historyResponseSchema,
+  lastActivitiesResponseSchema,
   minimalParamSchema,
   movieProgressResponseSchema,
   ratingsParamSchema,
@@ -458,6 +470,9 @@ export type HistoryAddRequest = z.infer<typeof bulkMediaRequestSchema>;
 export type HistoryRemoveRequest = z.infer<typeof historyRemoveRequestSchema>;
 export type HistoryResponse = z.infer<typeof historyResponseSchema>;
 export type HistoryRemoveResponse = z.infer<typeof historyRemoveResponseSchema>;
+export type LastActivitiesResponse = z.infer<
+  typeof lastActivitiesResponseSchema
+>;
 
 export type WatchlistRequest = z.infer<typeof listRequestSchema>;
 

--- a/projects/api/src/contracts/sync/schema/response/lastActivitiesResponseSchema.ts
+++ b/projects/api/src/contracts/sync/schema/response/lastActivitiesResponseSchema.ts
@@ -1,0 +1,80 @@
+import { z } from '../../../_internal/z.ts';
+
+const timestampSchema = z.string().datetime();
+
+const movieActivitiesSchema = z.object({
+  watched_at: timestampSchema,
+  collected_at: timestampSchema,
+  rated_at: timestampSchema,
+  watchlisted_at: timestampSchema,
+  favorited_at: timestampSchema,
+  commented_at: timestampSchema,
+  paused_at: timestampSchema,
+  hidden_at: timestampSchema,
+});
+
+const episodeActivitiesSchema = z.object({
+  watched_at: timestampSchema,
+  collected_at: timestampSchema,
+  rated_at: timestampSchema,
+  watchlisted_at: timestampSchema,
+  commented_at: timestampSchema,
+  paused_at: timestampSchema,
+});
+
+const showActivitiesSchema = z.object({
+  rated_at: timestampSchema,
+  watchlisted_at: timestampSchema,
+  favorited_at: timestampSchema,
+  commented_at: timestampSchema,
+  hidden_at: timestampSchema,
+  dropped_at: timestampSchema,
+});
+
+const seasonActivitiesSchema = z.object({
+  rated_at: timestampSchema,
+  watchlisted_at: timestampSchema,
+  commented_at: timestampSchema,
+  hidden_at: timestampSchema,
+});
+
+const commentActivitiesSchema = z.object({
+  liked_at: timestampSchema,
+  reacted_at: timestampSchema,
+  blocked_at: timestampSchema,
+});
+
+const listActivitiesSchema = z.object({
+  liked_at: timestampSchema,
+  reacted_at: timestampSchema,
+  updated_at: timestampSchema,
+  commented_at: timestampSchema,
+});
+
+const updatedActivitiesSchema = z.object({
+  updated_at: timestampSchema,
+});
+
+const accountActivitiesSchema = z.object({
+  settings_at: timestampSchema,
+  followed_at: timestampSchema,
+  following_at: timestampSchema,
+  pending_at: timestampSchema,
+  requested_at: timestampSchema,
+});
+
+export const lastActivitiesResponseSchema = z.object({
+  all: timestampSchema,
+  movies: movieActivitiesSchema,
+  episodes: episodeActivitiesSchema,
+  shows: showActivitiesSchema,
+  seasons: seasonActivitiesSchema,
+  comments: commentActivitiesSchema,
+  lists: listActivitiesSchema,
+  watchlist: updatedActivitiesSchema,
+  favorites: updatedActivitiesSchema,
+  collaborations: updatedActivitiesSchema,
+  account: accountActivitiesSchema,
+  saved_filters: updatedActivitiesSchema,
+  notes: updatedActivitiesSchema,
+});


### PR DESCRIPTION
Fixes: https://github.com/trakt/trakt-api/issues/820

## Problem

The new API docs are missing the `/sync/last_activities` endpoint.

## Solution

Added the missing sync contract route and response schema for `GET /sync/last_activities`, including the activity timestamp groups documented in the legacy Trakt API docs.

## Tests

- `git diff --check`

## Notes

I could not run the Deno test suite locally because Deno is not installed in this environment.
