### PR TITLE
fix(api): correct favorited response schemas

### DIFF
--- a/projects/api/src/contracts/movies/index.ts
+++ b/projects/api/src/contracts/movies/index.ts
@@ -42,6 +42,7 @@ import {
 } from '../_internal/response/watchNowResponseSchema.ts';
 import { z } from '../_internal/z.ts';
 import { movieAnticipatedResponseSchema } from './schema/response/movieAnticipatedResponseSchema.ts';
+import { movieFavoritedResponseSchema } from './schema/response/movieFavoritedResponseSchema.ts';
 import { movieHotResponseSchema } from './schema/response/movieHotResponseSchema.ts';
 import { movieStreamingResponseSchema } from './schema/response/movieStreamingResponseSchema.ts';
 import { movieTrendingResponseSchema } from './schema/response/movieTrendingResponseSchema.ts';
@@ -379,7 +380,7 @@ Returns the most favorited movies in the specified time \`period\`, defaulting t
       .merge(ignoreQuerySchema),
     pathParams: periodParamsSchema,
     responses: {
-      200: movieWatchedResponseSchema.array(),
+      200: movieFavoritedResponseSchema.array(),
     },
   },
   played: {
@@ -549,6 +550,12 @@ export { movieWatchedResponseSchema };
 /** The movie watched response payload. */
 export type MovieWatchedResponse = z.infer<
   typeof movieWatchedResponseSchema
+>;
+
+export { movieFavoritedResponseSchema };
+/** The movie favorited response payload. */
+export type MovieFavoritedResponse = z.infer<
+  typeof movieFavoritedResponseSchema
 >;
 
 export { movieAnticipatedResponseSchema };

--- a/projects/api/src/contracts/movies/schema/response/movieFavoritedResponseSchema.ts
+++ b/projects/api/src/contracts/movies/schema/response/movieFavoritedResponseSchema.ts
@@ -1,0 +1,8 @@
+import { movieResponseSchema } from '../../../_internal/response/movieResponseSchema.ts';
+import { z } from '../../../_internal/z.ts';
+
+/** Zod schema for the movie favorited response. */
+export const movieFavoritedResponseSchema = z.object({
+  user_count: z.number().int(),
+  movie: movieResponseSchema,
+});

--- a/projects/api/src/contracts/shows/index.ts
+++ b/projects/api/src/contracts/shows/index.ts
@@ -44,6 +44,7 @@ import { seasonParamsSchema } from './schema/request/seasonParamsSchema.ts';
 import { showQueryParamsSchema } from './schema/request/showQueryParamsSchema.ts';
 import { seasonResponseSchema } from './schema/response/seasonResponseSchema.ts';
 import { showAnticipatedResponseSchema } from './schema/response/showAnticipatedResponseSchema.ts';
+import { showFavoritedResponseSchema } from './schema/response/showFavoritedResponseSchema.ts';
 import { showHotResponseSchema } from './schema/response/showHotResponseSchema.ts';
 import { showProgressResponseSchema } from './schema/response/showProgressResponseSchema.ts';
 import { showStreamingResponseSchema } from './schema/response/showStreamingResponseSchema.ts';
@@ -873,7 +874,7 @@ Returns the most favorited shows in the specified time \`period\`, defaulting to
       .merge(ignoreQuerySchema),
     pathParams: periodParamsSchema,
     responses: {
-      200: showWatchedResponseSchema.array(),
+      200: showFavoritedResponseSchema.array(),
     },
   },
   played: {
@@ -1024,6 +1025,10 @@ export type ShowTrendingResponse = z.infer<typeof showTrendingResponseSchema>;
 export { showWatchedResponseSchema };
 /** The show watched response payload. */
 export type ShowWatchedResponse = z.infer<typeof showWatchedResponseSchema>;
+
+export { showFavoritedResponseSchema };
+/** The show favorited response payload. */
+export type ShowFavoritedResponse = z.infer<typeof showFavoritedResponseSchema>;
 
 /** The show stats response payload. */
 export type ShowStatsResponse = z.infer<typeof showStatsResponseSchema>;

--- a/projects/api/src/contracts/shows/schema/response/showFavoritedResponseSchema.ts
+++ b/projects/api/src/contracts/shows/schema/response/showFavoritedResponseSchema.ts
@@ -1,0 +1,8 @@
+import { showResponseSchema } from '../../../_internal/response/showResponseSchema.ts';
+import { z } from '../../../_internal/z.ts';
+
+/** Zod schema for the show favorited response. */
+export const showFavoritedResponseSchema = z.object({
+  user_count: z.number().int(),
+  show: showResponseSchema,
+});


### PR DESCRIPTION
Fixes #830.

Updates the movies and shows favorited endpoint contracts so the generated documentation matches the actual response shape. The favorited endpoints now document `user_count` with the related `movie` or `show`, instead of reusing watched response stats.