### PR TITLE
feat: Adds user locale setting

### DIFF
--- a/projects/api/deno.json
+++ b/projects/api/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@trakt/api",
   "exports": "./src/index.ts",
-  "version": "0.4.19",
+  "version": "0.4.20",
   "imports": {
     "@anatine/zod-openapi": "npm:@anatine/zod-openapi@^2.2.6",
     "@std/testing": "jsr:@std/testing@^1.0.5",

--- a/projects/api/src/contracts/users/schema/request/settingsRequestSchema.ts
+++ b/projects/api/src/contracts/users/schema/request/settingsRequestSchema.ts
@@ -29,6 +29,7 @@ const browsingSettingsSchema = z.object({
   dark_knight: z.enum(['true', 'false', 'auto']).nullish(),
   watch_only_once: z.boolean().nullish(),
   show_rating_prompt: z.boolean().nullish(),
+  locale: z.string().nullish(),
 });
 
 export const settingsRequestSchema = z.object({

--- a/projects/api/src/contracts/users/schema/response/settingsResponseSchema.ts
+++ b/projects/api/src/contracts/users/schema/response/settingsResponseSchema.ts
@@ -44,6 +44,7 @@ export const settingsResponseSchema = z.object({
     watch_after_rating: z.string().nullish(),
     watch_only_once: z.boolean(),
     show_rating_prompt: z.boolean().nullish(),
+    locale: z.string().nullish(),
     other_site_ratings: z.boolean(),
     release_date_ignore_runtime: z.boolean(),
     display_early_ratings: z.boolean(),


### PR DESCRIPTION
## 🎶 Notes 🎶
- Adds support for a user `locale` setting, allowing users to specify their preferred language and region within their account settings.
- Updates the user settings request and response schemas to include the new `locale` field, ensuring it can be submitted and retrieved via the API.
- Bumps the API package version to reflect the new feature.