### PR TITLE
Adds language filter for comments

### DIFF
--- a/projects/api/deno.json
+++ b/projects/api/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@trakt/api",
   "exports": "./src/index.ts",
-  "version": "0.4.20",
+  "version": "0.4.21",
   "imports": {
     "@anatine/zod-openapi": "npm:@anatine/zod-openapi@^2.2.6",
     "@std/testing": "jsr:@std/testing@^1.0.5",

--- a/projects/api/src/contracts/_internal/request/languageQuerySchema.ts
+++ b/projects/api/src/contracts/_internal/request/languageQuerySchema.ts
@@ -1,0 +1,7 @@
+import { z } from '../z.ts';
+
+export const languageQuerySchema = z.object({
+  language: z.string().nullish().openapi({
+    description: 'Filter comments to a 2 character language code',
+  }),
+});

--- a/projects/api/src/contracts/movies/index.ts
+++ b/projects/api/src/contracts/movies/index.ts
@@ -18,6 +18,7 @@ import { recentPeriodParamsSchema } from '../_internal/request/recentPeriodParam
 import { refreshQuerySchema } from '../_internal/request/refreshQuerySchema.ts';
 import { commentResponseSchema } from '../_internal/response/commentResponseSchema.ts';
 import type { genreEnumSchema } from '../_internal/response/genreEnumSchema.ts';
+import { languageQuerySchema } from '../_internal/request/languageQuerySchema.ts';
 import { justWatchLinkResponseSchema } from '../_internal/response/justWatchLinkResponseSchema.ts';
 import { listResponseSchema } from '../_internal/response/listResponseSchema.ts';
 import { listSortSchema } from '../_internal/response/listSortSchema.ts';
@@ -273,7 +274,8 @@ Returns all top level comments for a movie. By default, comments are sorted by m
     method: 'GET',
     query: extendedProfileQuerySchema
       .merge(pageQuerySchema)
-      .merge(limitlessQuerySchema),
+      .merge(limitlessQuerySchema)
+      .merge(languageQuerySchema),
     pathParams: idParamsSchema.merge(commentsSortParamsSchema),
     responses: {
       200: commentResponseSchema.array(),

--- a/projects/api/src/contracts/shows/index.ts
+++ b/projects/api/src/contracts/shows/index.ts
@@ -21,6 +21,7 @@ import { commentResponseSchema } from '../_internal/response/commentResponseSche
 import { episodeResponseSchema } from '../_internal/response/episodeResponseSchema.ts';
 import { episodeStatsResponseSchema } from '../_internal/response/episodeStatsResponseSchema.ts';
 import { episodeTranslationResponseSchema } from '../_internal/response/episodeTranslationResponseSchema.ts';
+import { languageQuerySchema } from '../_internal/request/languageQuerySchema.ts';
 import { justWatchLinkResponseSchema } from '../_internal/response/justWatchLinkResponseSchema.ts';
 import { listResponseSchema } from '../_internal/response/listResponseSchema.ts';
 import { listSortSchema } from '../_internal/response/listSortSchema.ts';
@@ -153,7 +154,8 @@ Returns all top level comments for an episode. By default, comments are sorted b
       .merge(commentsSortParamsSchema),
     query: extendedProfileQuerySchema
       .merge(pageQuerySchema)
-      .merge(limitlessQuerySchema),
+      .merge(limitlessQuerySchema)
+      .merge(languageQuerySchema),
     responses: {
       200: commentResponseSchema.array(),
     },
@@ -594,7 +596,8 @@ Returns all top level comments for a season. By default, comments are sorted by 
         .merge(commentsSortParamsSchema),
       query: extendedProfileQuerySchema
         .merge(pageQuerySchema)
-        .merge(limitlessQuerySchema),
+        .merge(limitlessQuerySchema)
+        .merge(languageQuerySchema),
       responses: {
         200: commentResponseSchema.array(),
       },
@@ -762,7 +765,8 @@ Returns all top level comments for a show. By default, comments are sorted by mo
       .merge(commentsSortParamsSchema),
     query: extendedProfileQuerySchema
       .merge(pageQuerySchema)
-      .merge(limitlessQuerySchema),
+      .merge(limitlessQuerySchema)
+      .merge(languageQuerySchema),
     responses: {
       200: commentResponseSchema.array(),
     },


### PR DESCRIPTION
## 🎶 Notes 🎶
- Implements a `language` query parameter for filtering comments by a 2-character language code.
- Applies the language filter to all movie, show, season, and episode comment endpoints.
- Bumps the API version to 0.4.21.

## 👀 Example 👀
Example with language: `pt`

https://github.com/user-attachments/assets/1a8220e3-1bee-49e2-aa72-62bb4a6ac4d4

