### PR TITLE
feat(calendars): add hot releases endpoint contract

### DIFF
--- a/projects/api/deno.json
+++ b/projects/api/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@trakt/api",
   "exports": "./src/index.ts",
-  "version": "0.4.21",
+  "version": "0.4.22",
   "imports": {
     "@anatine/zod-openapi": "npm:@anatine/zod-openapi@^2.2.6",
     "@std/testing": "jsr:@std/testing@^1.0.5",

--- a/projects/api/src/contracts/calendars/index.ts
+++ b/projects/api/src/contracts/calendars/index.ts
@@ -2,10 +2,11 @@ import { builder } from '../_internal/builder.ts';
 import { extendedMediaQuerySchema } from '../_internal/request/extendedMediaQuerySchema.ts';
 import { ignoreQuerySchema } from '../_internal/request/ignoreQuerySchema.ts';
 import { mediaFilterParamsSchema } from '../_internal/request/mediaFilterParamsSchema.ts';
-import type { z } from '../_internal/z.ts';
+import { z } from '../_internal/z.ts';
 import { calendarRequestParamsSchema } from './schema/request/calendarParamsSchema.ts';
 import { calendarMovieResponseSchema } from './schema/response/calendarMovieResponseSchema.ts';
 import { calendarShowResponseSchema } from './schema/response/calendarShowListResponseSchema.ts';
+import { hotReleaseResponseSchema } from './schema/response/hotReleaseResponseSchema.ts';
 
 export const calendars = builder.router({
   shows: {
@@ -106,6 +107,25 @@ Returns DVD and physical media releases during the requested UTC date range. Use
       200: calendarMovieResponseSchema.array(),
     },
   },
+  releasesHot: {
+    summary: 'Get hot releases',
+    description: `#### ✨ Extended Info 🎚 Filters
+Returns the merged feed of upcoming movies and episodes during the requested UTC date range that are trending or highly anticipated, ordered by availability date. This is the global feed only; use \`type\` to narrow to a single media type.`,
+    method: 'GET',
+    path: '/releases/hot/:start_date/:days',
+    query: extendedMediaQuerySchema
+      .merge(mediaFilterParamsSchema)
+      .merge(z.object({
+        type: z.enum(['movie', 'show']).optional().openapi({
+          description:
+            'Narrow the feed to a single media type. Omit to return both.',
+        }),
+      })),
+    pathParams: calendarRequestParamsSchema.omit({ target: true }),
+    responses: {
+      200: hotReleaseResponseSchema.array(),
+    },
+  },
 }, { pathPrefix: '/calendars' });
 
 export { calendarRequestParamsSchema };
@@ -118,3 +138,6 @@ export type CalendarShowResponse = z.infer<
 
 export { calendarMovieResponseSchema };
 export type CalendarMovieResponse = z.infer<typeof calendarMovieResponseSchema>;
+
+export { hotReleaseResponseSchema };
+export type HotReleaseResponse = z.infer<typeof hotReleaseResponseSchema>;

--- a/projects/api/src/contracts/calendars/schema/response/hotReleaseResponseSchema.ts
+++ b/projects/api/src/contracts/calendars/schema/response/hotReleaseResponseSchema.ts
@@ -1,0 +1,13 @@
+import { z } from '../../../_internal/z.ts';
+import { calendarMovieResponseSchema } from './calendarMovieResponseSchema.ts';
+import { calendarShowResponseSchema } from './calendarShowListResponseSchema.ts';
+
+/**
+ * A single entry in the merged hot-releases feed: either an upcoming movie or
+ * an upcoming episode. Discriminate by shape — movie entries carry `movie`,
+ * episode entries carry `episode`/`show`.
+ */
+export const hotReleaseResponseSchema = z.union([
+  calendarMovieResponseSchema,
+  calendarShowResponseSchema,
+]);


### PR DESCRIPTION
## What

Adds the contract for a new global calendar endpoint:

```
GET /calendars/releases/hot/:start_date/:days   (?type=movie|show)
```

Returns a single merged feed of upcoming movies and episodes in the window that are trending or highly anticipated, ordered by availability date. `type` narrows to one media type; omitted returns both. The response is a union of the existing movie and episode calendar entries (`hotReleaseResponseSchema`), so consumers discriminate by shape (`movie` vs `episode`/`show`).

No `target` path param: this is the global feed only, so the shared calendar params schema is reused via `.omit({ target: true })`.

## Why

Backs the "hot releases" surface, which today is assembled client-side from a releases-calendar fetch plus separate trending/anticipated fetches and an in-browser intersect. The worker now serves that server-side (trakt/trakt-workers#1181); this contract exposes it typed.

## Version

Bumps `@trakt/api` to 0.4.22.

## Notes

The 5 pre-existing `sync/HistoryRequest.test.ts` type-check failures are unrelated to this change (untouched here).