### PR TITLE
feat(calendar): add merged media endpoint contract

### DIFF
--- a/projects/api/deno.json
+++ b/projects/api/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@trakt/api",
   "exports": "./src/index.ts",
-  "version": "0.4.22",
+  "version": "0.4.23",
   "imports": {
     "@anatine/zod-openapi": "npm:@anatine/zod-openapi@^2.2.6",
     "@std/testing": "jsr:@std/testing@^1.0.5",

--- a/projects/api/src/contracts/calendars/index.ts
+++ b/projects/api/src/contracts/calendars/index.ts
@@ -107,6 +107,25 @@ Returns DVD and physical media releases during the requested UTC date range. Use
       200: calendarMovieResponseSchema.array(),
     },
   },
+  media: {
+    summary: 'Get media',
+    description: `#### ✨ Extended Info 🎚 Filters
+Returns the merged feed of movies and episodes during the requested UTC date range, ordered by availability date. Use \`target\` to choose the authenticated user calendar (\`my\`) or the global calendar (\`all\`), and \`type\` to narrow to a single media type.`,
+    method: 'GET',
+    path: '/:target/media/:start_date/:days',
+    query: extendedMediaQuerySchema
+      .merge(mediaFilterParamsSchema)
+      .merge(z.object({
+        type: z.enum(['movie', 'show']).optional().openapi({
+          description:
+            'Narrow the feed to a single media type. Omit to return both.',
+        }),
+      })),
+    pathParams: calendarRequestParamsSchema,
+    responses: {
+      200: hotReleaseResponseSchema.array(),
+    },
+  },
   releasesHot: {
     summary: 'Get hot releases',
     description: `#### ✨ Extended Info 🎚 Filters


### PR DESCRIPTION
## What

Adds the contract for the merged media calendar:

```
GET /calendars/:target/media/:start_date/:days   (?type=movie|show)
```

Per target (`my` / `all`), returns a single feed of movies and episodes for the window, ordered by availability date. `type` narrows to one media type; omitted returns both. The response reuses the movie/episode union schema (`hotReleaseResponseSchema`).

## Why

Backs the standard-calendar mirror of the hot-releases collapse. The worker serves it (trakt/trakt-workers#1182, merged); this exposes it typed so trakt-web can drop its two-request upcoming-media feed to one call.

## Version

Bumps `@trakt/api` to 0.4.23.