### PR TITLE
feat(calendar): add group=day param + grouped episode shape

### DIFF
--- a/projects/api/deno.json
+++ b/projects/api/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@trakt/api",
   "exports": "./src/index.ts",
-  "version": "0.4.23",
+  "version": "0.4.24",
   "imports": {
     "@anatine/zod-openapi": "npm:@anatine/zod-openapi@^2.2.6",
     "@std/testing": "jsr:@std/testing@^1.0.5",

--- a/projects/api/src/contracts/calendars/index.ts
+++ b/projects/api/src/contracts/calendars/index.ts
@@ -8,6 +8,13 @@ import { calendarMovieResponseSchema } from './schema/response/calendarMovieResp
 import { calendarShowResponseSchema } from './schema/response/calendarShowListResponseSchema.ts';
 import { hotReleaseResponseSchema } from './schema/response/hotReleaseResponseSchema.ts';
 
+const groupQuery = z.object({
+  group: z.enum(['day']).optional().openapi({
+    description:
+      'Collapse same-show-same-day episodes into a single card (`full_season` / `multiple_episodes`). Omit for one entry per episode.',
+  }),
+});
+
 export const calendars = builder.router({
   shows: {
     summary: 'Get shows',
@@ -17,7 +24,8 @@ Returns shows airing during the requested UTC date range. Use \`target\` to choo
     path: '/:target/shows/:start_date/:days',
     query: extendedMediaQuerySchema
       .merge(mediaFilterParamsSchema)
-      .merge(ignoreQuerySchema),
+      .merge(ignoreQuerySchema)
+      .merge(groupQuery),
     pathParams: calendarRequestParamsSchema,
     responses: {
       200: calendarShowResponseSchema.array(),
@@ -120,7 +128,8 @@ Returns the merged feed of movies and episodes during the requested UTC date ran
           description:
             'Narrow the feed to a single media type. Omit to return both.',
         }),
-      })),
+      }))
+      .merge(groupQuery),
     pathParams: calendarRequestParamsSchema,
     responses: {
       200: hotReleaseResponseSchema.array(),
@@ -139,7 +148,8 @@ Returns the merged feed of upcoming movies and episodes during the requested UTC
           description:
             'Narrow the feed to a single media type. Omit to return both.',
         }),
-      })),
+      }))
+      .merge(groupQuery),
     pathParams: calendarRequestParamsSchema.omit({ target: true }),
     responses: {
       200: hotReleaseResponseSchema.array(),

--- a/projects/api/src/contracts/calendars/schema/response/calendarEpisodeResponseSchema.ts
+++ b/projects/api/src/contracts/calendars/schema/response/calendarEpisodeResponseSchema.ts
@@ -1,0 +1,26 @@
+import { episodeResponseSchema } from '../../../_internal/response/episodeResponseSchema.ts';
+import { z } from '../../../_internal/z.ts';
+
+/**
+ * Episode as returned by the calendar endpoints. Extends the shared episode
+ * with the day-grouping fields that `?group=day` populates: `episode_type` can
+ * additionally be a computed card type, and `episodes` holds the collapsed
+ * group. Both are nullish, so a single shape covers the raw and grouped feeds
+ * without touching the shared `episodeResponseSchema`.
+ */
+export const calendarEpisodeResponseSchema = episodeResponseSchema.extend({
+  episode_type: z
+    .enum([
+      'standard',
+      'series_premiere',
+      'season_premiere',
+      'mid_season_finale',
+      'mid_season_premiere',
+      'season_finale',
+      'series_finale',
+      'full_season',
+      'multiple_episodes',
+    ])
+    .nullish(),
+  episodes: episodeResponseSchema.array().nullish(),
+});

--- a/projects/api/src/contracts/calendars/schema/response/calendarShowListResponseSchema.ts
+++ b/projects/api/src/contracts/calendars/schema/response/calendarShowListResponseSchema.ts
@@ -1,9 +1,9 @@
-import { episodeResponseSchema } from '../../../_internal/response/episodeResponseSchema.ts';
 import { showResponseSchema } from '../../../_internal/response/showResponseSchema.ts';
 import { z } from '../../../_internal/z.ts';
+import { calendarEpisodeResponseSchema } from './calendarEpisodeResponseSchema.ts';
 
 export const calendarShowResponseSchema = z.object({
   first_aired: z.string(),
-  episode: episodeResponseSchema,
+  episode: calendarEpisodeResponseSchema,
   show: showResponseSchema,
 });


### PR DESCRIPTION
## What

Two related changes to the calendar contract.

**1. `?group=day`** on the episode-bearing feeds that can carry multiple same-day episodes per show (`shows`, `media`, `releasesHot`). Collapses same-show-same-day episodes into one card. A calendar-specific episode schema (`calendarEpisodeResponseSchema`) carries the grouping fields - `episode_type` gains `full_season` / `multiple_episodes`, and `episodes` holds the collapsed group (both nullish; the shared `episodeResponseSchema` is untouched). Not on premieres/finales/new (one per show/day - no-op) or movie-only streaming/dvd.

**2. Flat merged-feed shape.** The merged-feed response (`hotReleaseResponseSchema`, used by `media` + `releasesHot`) moves from `z.union([movie, show])` to a single flat object with every field nullish. OpenAPI codegen renders a union `oneOf` as a model with all fields required, so consumers generated a wrong schema (per @mike's report). Nullish fields generate a correct optional-field model. Documented as a convention in a new `AGENTS.md`.

## Why

Backs moving trakt-web's `coalesceEpisodes` server-side (trakt/trakt-workers#1183) and fixes the union-response codegen for consumers.

## Version

Bumps `@trakt/api` to 0.4.24.