### PR TITLE
feat(calendar): add hot premieres/finales/new endpoint contracts

### DIFF
--- a/projects/api/deno.json
+++ b/projects/api/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@trakt/api",
   "exports": "./src/index.ts",
-  "version": "0.4.25",
+  "version": "0.4.26",
   "imports": {
     "@anatine/zod-openapi": "npm:@anatine/zod-openapi@^2.2.6",
     "@std/testing": "jsr:@std/testing@^1.0.5",

--- a/projects/api/src/contracts/calendars/index.ts
+++ b/projects/api/src/contracts/calendars/index.ts
@@ -155,6 +155,42 @@ Returns the merged feed of upcoming movies and episodes during the requested UTC
       200: hotReleaseResponseSchema.array(),
     },
   },
+  releasesHotPremieres: {
+    summary: 'Get hot premieres',
+    description: `#### ✨ Extended Info 🎚 Filters
+Returns upcoming show premieres during the requested UTC date range that are trending or highly anticipated. Curated global feed - daily-cadence formats (soap, talk, news, game shows) and specials are excluded.`,
+    method: 'GET',
+    path: '/releases/hot/premieres/:start_date/:days',
+    query: extendedMediaQuerySchema.merge(mediaFilterParamsSchema),
+    pathParams: calendarRequestParamsSchema.omit({ target: true }),
+    responses: {
+      200: calendarShowResponseSchema.array(),
+    },
+  },
+  releasesHotFinales: {
+    summary: 'Get hot finales',
+    description: `#### ✨ Extended Info 🎚 Filters
+Returns upcoming show finales during the requested UTC date range that are trending or highly anticipated. Curated global feed - daily-cadence formats (soap, talk, news, game shows) and specials are excluded.`,
+    method: 'GET',
+    path: '/releases/hot/finales/:start_date/:days',
+    query: extendedMediaQuerySchema.merge(mediaFilterParamsSchema),
+    pathParams: calendarRequestParamsSchema.omit({ target: true }),
+    responses: {
+      200: calendarShowResponseSchema.array(),
+    },
+  },
+  releasesHotNew: {
+    summary: 'Get hot new shows',
+    description: `#### ✨ Extended Info 🎚 Filters
+Returns upcoming series premieres during the requested UTC date range that are trending or highly anticipated. Curated global feed - daily-cadence formats (soap, talk, news, game shows) and specials are excluded.`,
+    method: 'GET',
+    path: '/releases/hot/new/:start_date/:days',
+    query: extendedMediaQuerySchema.merge(mediaFilterParamsSchema),
+    pathParams: calendarRequestParamsSchema.omit({ target: true }),
+    responses: {
+      200: calendarShowResponseSchema.array(),
+    },
+  },
 }, { pathPrefix: '/calendars' });
 
 export { calendarRequestParamsSchema };


### PR DESCRIPTION
## What

Adds contract methods for the hot episode-status feeds:

- `GET /calendars/releases/hot/premieres/:start_date/:days`
- `GET /calendars/releases/hot/finales/:start_date/:days`
- `GET /calendars/releases/hot/new/:start_date/:days`

Shows-only responses (`calendarShowResponseSchema`). No `target` (global/hot only), no `type` or `group` - episode statuses are single-type and one premiere/finale per show per day.

## Why

Exposes the worker's hot-status endpoints (trakt/trakt-workers#1194) typed for clients.

## Version

Bumps `@trakt/api` to 0.4.26.