### PR TITLE
feat: add smart lists endpoints to contract

### DIFF
--- a/projects/api/src/contracts/_internal/request/smartListFiltersSchema.ts
+++ b/projects/api/src/contracts/_internal/request/smartListFiltersSchema.ts
@@ -1,0 +1,23 @@
+import { z } from '../z.ts';
+
+const list = z.array(z.string());
+const range = z.array(z.number()).max(2);
+
+export const smartListFiltersSchema = z.object({
+  genres: list.optional(),
+  subgenres: list.optional(),
+  certifications: list.optional(),
+  languages: list.optional(),
+  countries: list.optional(),
+  statuses: list.optional(),
+  networks: list.optional(),
+  watchnow: list.optional(),
+  years: range.optional(),
+  ratings: range.optional(),
+  runtimes: range.optional(),
+  imdb_ratings: range.optional(),
+  rt_meters: range.optional(),
+  rt_user_meters: range.optional(),
+  ignore_watched: z.boolean().optional(),
+  ignore_watchlisted: z.boolean().optional(),
+});

--- a/projects/api/src/contracts/_internal/request/smartListWriteSchema.ts
+++ b/projects/api/src/contracts/_internal/request/smartListWriteSchema.ts
@@ -1,0 +1,16 @@
+import { z } from '../z.ts';
+import { smartListFiltersSchema } from './smartListFiltersSchema.ts';
+
+export const smartListWriteSchema = z.object({
+  name: z.string().min(1),
+  source: z.enum([
+    'trending',
+    'popular',
+    'anticipated',
+    'recommendations',
+    'discover',
+  ]),
+  media_type: z.enum(['movies', 'shows', 'media']),
+  filters: smartListFiltersSchema.optional(),
+  privacy: z.enum(['public', 'private', 'friends']).optional(),
+});

--- a/projects/api/src/contracts/_internal/response/smartListCreateResponseSchema.ts
+++ b/projects/api/src/contracts/_internal/response/smartListCreateResponseSchema.ts
@@ -1,0 +1,8 @@
+import { z } from '../z.ts';
+
+export const smartListCreateResponseSchema = z.object({
+  ids: z.object({
+    trakt: z.number().int(),
+    slug: z.string(),
+  }),
+});

--- a/projects/api/src/contracts/_internal/response/smartListDefinitionResponseSchema.ts
+++ b/projects/api/src/contracts/_internal/response/smartListDefinitionResponseSchema.ts
@@ -1,0 +1,19 @@
+import { smartListFiltersSchema } from '../request/smartListFiltersSchema.ts';
+import { z } from '../z.ts';
+
+export const smartListDefinitionResponseSchema = z.object({
+  name: z.string(),
+  privacy: z.string(),
+  created_at: z.string().datetime(),
+  updated_at: z.string().datetime(),
+  ids: z.object({
+    trakt: z.number().int(),
+    slug: z.string(),
+  }),
+  images: z.object({
+    posters: z.string().array(),
+  }),
+  source: z.string(),
+  media_type: z.string(),
+  filters: smartListFiltersSchema,
+});

--- a/projects/api/src/contracts/_internal/response/smartListItemResponseSchema.ts
+++ b/projects/api/src/contracts/_internal/response/smartListItemResponseSchema.ts
@@ -1,0 +1,10 @@
+import { listedMovieResponseSchema } from './listedMovieResponseSchema.ts';
+import { listedShowResponseSchema } from './listedShowResponseSchema.ts';
+import { z } from '../z.ts';
+
+export const smartListItemResponseSchema = z.object({
+  rank: z.number().int(),
+  type: z.string(),
+  movie: listedMovieResponseSchema.nullish(),
+  show: listedShowResponseSchema.nullish(),
+});

--- a/projects/api/src/contracts/smart_lists/index.ts
+++ b/projects/api/src/contracts/smart_lists/index.ts
@@ -1,0 +1,55 @@
+import { builder } from '../_internal/builder.ts';
+import { extendedMediaQuerySchema } from '../_internal/request/extendedMediaQuerySchema.ts';
+import { ignoreQuerySchema } from '../_internal/request/ignoreQuerySchema.ts';
+import { limitlessQuerySchema } from '../_internal/request/limitlessQuerySchema.ts';
+import { mediaFilterParamsSchema } from '../_internal/request/mediaFilterParamsSchema.ts';
+import { pageQuerySchema } from '../_internal/request/pageQuerySchema.ts';
+import { smartListDefinitionResponseSchema } from '../_internal/response/smartListDefinitionResponseSchema.ts';
+import { smartListItemResponseSchema } from '../_internal/response/smartListItemResponseSchema.ts';
+import { z } from '../_internal/z.ts';
+import { listParamsSchema } from '../users/schema/request/listParamsSchema.ts';
+
+const listItemsPathParamsSchema = listParamsSchema.extend({
+  type: z.string().describe('Smart list item type filter.'),
+  sort_by: z.string().describe('Sort by a specific property.'),
+  sort_how: z.string().describe('Sort direction.'),
+});
+
+export const smartLists = builder.router({
+  summary: {
+    summary: 'Get smart list',
+    description: `#### 🔓 OAuth Optional 😁 Emojis
+Returns a single smart list definition by its globally-unique slug. Use the [**/smart-lists/:list_id/items**](#reference/smart-lists) method to get the dynamic items this smart list resolves to.
+
+> ### Note
+> _Only public smart lists return data unless you send OAuth as the owner._`,
+    path: '/:list_id',
+    method: 'GET',
+    pathParams: listParamsSchema,
+    responses: {
+      200: smartListDefinitionResponseSchema,
+      404: z.undefined(),
+    },
+  },
+  items: {
+    summary: 'Get smart list items',
+    description:
+      `#### 🔓 OAuth Optional 📄 Pagination ✨ Extended Info 🎚 Filters 😁 Emojis
+Returns the dynamic items a smart list resolves to. Use \`type\`, \`sort_by\`, and \`sort_how\` to control the returned item set and order, plus query filters and pagination to refine the result set.`,
+    path: '/:list_id/items/:type/:sort_by/:sort_how',
+    method: 'GET',
+    pathParams: listItemsPathParamsSchema,
+    query: extendedMediaQuerySchema
+      .merge(mediaFilterParamsSchema)
+      .merge(ignoreQuerySchema)
+      .merge(pageQuerySchema)
+      .merge(limitlessQuerySchema),
+    responses: {
+      200: smartListItemResponseSchema.array(),
+    },
+  },
+}, {
+  pathPrefix: '/smart-lists',
+});
+
+export type SmartListItemResponse = z.infer<typeof smartListItemResponseSchema>;

--- a/projects/api/src/contracts/traktContract.ts
+++ b/projects/api/src/contracts/traktContract.ts
@@ -19,6 +19,7 @@ import { scrobble } from './scrobble/index.ts';
 import { search } from './search/index.ts';
 import { seasons } from './seasons/index.ts';
 import { shows } from './shows/index.ts';
+import { smartLists } from './smart_lists/index.ts';
 import { social_recommendations } from './social_recommendations/index.ts';
 import { sync } from './sync/index.ts';
 import { team } from './team/index.ts';
@@ -45,6 +46,7 @@ export const traktContract = builder
     seasons,
     episodes,
     lists,
+    smart_lists: smartLists,
     comments,
     certifications,
     countries,

--- a/projects/api/src/contracts/users/index.ts
+++ b/projects/api/src/contracts/users/index.ts
@@ -65,6 +65,7 @@ import { hidden } from './subroutes/hidden.ts';
 import { history } from './subroutes/history.ts';
 import { ratings } from './subroutes/ratings.ts';
 import { requests } from './subroutes/requests.ts';
+import { smartLists } from './subroutes/smartLists.ts';
 import { userLists } from './subroutes/userLists.ts';
 import { watched } from './subroutes/watched.ts';
 import { watchlist } from './subroutes/watchlist.ts';
@@ -642,6 +643,7 @@ export const users = builder.router({
   ratings,
   favorites,
   lists: userLists,
+  smartLists,
   hidden,
   requests,
   filters,
@@ -655,6 +657,7 @@ export type * from './subroutes/hidden.ts';
 export type * from './subroutes/history.ts';
 export type * from './subroutes/ratings.ts';
 export type * from './subroutes/requests.ts';
+export type * from './subroutes/smartLists.ts';
 export type * from './subroutes/userLists.ts';
 export type * from './subroutes/watched.ts';
 export type * from './subroutes/watchlist.ts';

--- a/projects/api/src/contracts/users/subroutes/smartLists.ts
+++ b/projects/api/src/contracts/users/subroutes/smartLists.ts
@@ -1,0 +1,94 @@
+import { smartListCreateResponseSchema } from '../../_internal/response/smartListCreateResponseSchema.ts';
+import { smartListDefinitionResponseSchema } from '../../_internal/response/smartListDefinitionResponseSchema.ts';
+import { smartListWriteSchema } from '../../_internal/request/smartListWriteSchema.ts';
+import { builder } from '../../_internal/builder.ts';
+import { z } from '../../_internal/z.ts';
+import { listParamsSchema } from '../schema/request/listParamsSchema.ts';
+import { profileParamsSchema } from '../schema/request/profileParamsSchema.ts';
+
+const smartList = builder.router({
+  summary: {
+    summary: 'Get smart list',
+    description: `#### 🔓 OAuth Optional
+Returns a single smart list definition. Use the [**/users/:id/smart-lists/:list_id/items**](#reference/users) method to get the dynamic items this smart list resolves to.`,
+    path: '/',
+    method: 'GET',
+    pathParams: profileParamsSchema.merge(listParamsSchema),
+    responses: {
+      200: smartListDefinitionResponseSchema,
+      404: z.undefined(),
+    },
+  },
+  update: {
+    summary: 'Update smart list',
+    description: `#### 🔒 OAuth Required
+Update a smart list by sending 1 or more parameters. The \`source\`, \`media_type\`, \`filters\`, and \`privacy\` can all be changed; the slug is retained so existing references keep working.`,
+    path: '/',
+    method: 'PUT',
+    pathParams: profileParamsSchema.merge(listParamsSchema),
+    body: smartListWriteSchema.partial(),
+    responses: {
+      200: smartListDefinitionResponseSchema,
+      404: z.undefined(),
+    },
+  },
+  delete: {
+    summary: "Delete a user's smart list",
+    description: `#### 🔒 OAuth Required
+Remove a smart list.`,
+    path: '/',
+    method: 'DELETE',
+    pathParams: profileParamsSchema.merge(listParamsSchema),
+    responses: {
+      204: z.undefined(),
+      404: z.undefined(),
+    },
+  },
+}, {
+  pathPrefix: '/:list_id',
+});
+
+export const smartLists = builder.router({
+  personal: {
+    summary: "Get a user's smart lists",
+    description: `#### 🔓 OAuth Optional
+Returns all smart list definitions for a user. Use the [**/users/:id/smart-lists/:list_id/items**](#reference/users) method to get the dynamic items a specific smart list resolves to.`,
+    path: '',
+    method: 'GET',
+    pathParams: profileParamsSchema,
+    responses: {
+      200: smartListDefinitionResponseSchema.array(),
+    },
+  },
+  create: {
+    summary: 'Create smart list',
+    description: `#### 🔥 VIP Enhanced 🔒 OAuth Required
+Create a new smart list. A smart list is a dynamic list driven by a \`source\` and \`filters\` rather than manually added items.
+
+#### JSON POST Data
+| Key | Type | Value |
+|---|---|---|
+| \`name\` * | string | Name of the smart list. |
+| \`source\` * | string | \`trending\`, \`popular\`, \`anticipated\`, \`recommendations\`, \`discover\` |
+| \`media_type\` * | string | \`movies\`, \`shows\`, \`media\` |
+| \`filters\` | object | Filter constraints applied to the source. |
+| \`privacy\` | string | \`public\`, \`private\`, \`friends\` |`,
+    path: '',
+    method: 'POST',
+    body: smartListWriteSchema,
+    responses: {
+      201: smartListCreateResponseSchema,
+    },
+  },
+  smartList,
+}, {
+  pathPrefix: '/:id/smart-lists',
+});
+
+export type SmartListWriteRequest = z.infer<typeof smartListWriteSchema>;
+export type SmartListDefinitionResponse = z.infer<
+  typeof smartListDefinitionResponseSchema
+>;
+export type SmartListCreateResponse = z.infer<
+  typeof smartListCreateResponseSchema
+>;


### PR DESCRIPTION
Adds the smart lists endpoints to the `@trakt/api` contract, backing the server-materialized dynamic-list feature already shipped in trakt-workers.

## Endpoints

**User-scoped** (`/users/:id/smart-lists`, mirrors `userLists`):
- `GET ''` - list a user's smart list definitions
- `POST ''` - create a smart list
- `GET /:list_id` - get one definition
- `PUT /:list_id` - update
- `DELETE /:list_id` - delete

**Slug-addressable** (`/smart-lists`, mirrors `lists/`):
- `GET /:list_id` - definition by globally-unique slug
- `GET /:list_id/items/:type/:sort_by/:sort_how` - the dynamic items the list resolves to (paginated, extended, filters)

## Schemas

Five shared zod schemas under `_internal/{request,response}` (single source of truth for both contracts):
- `smartListWriteSchema` - `name`, `source` (`trending`/`popular`/`anticipated`/`recommendations`/`discover`), `media_type` (`movies`/`shows`/`media`), optional `filters`, optional `privacy` (`public`/`private`/`friends`)
- `smartListFiltersSchema` - the filter contract (genre/language/country/network/watchnow lists, rating/year/runtime ranges, ignore flags)
- `smartListDefinitionResponseSchema`, `smartListCreateResponseSchema`, `smartListItemResponseSchema` (flat + nullish `movie`/`show`, per the polymorphic-response convention)

## Notes

- Items path params (`:type/:sort_by/:sort_how`) are required, mirroring `userLists` typedSorted - the OpenAPI generator can't emit optional path segments. This is a safe subset of the worker route, which accepts them as optional.
- `openapi:generate` + `openapi:validate` pass. The pre-existing lint (`no-explicit-any` in `generateOpenApi.ts`) and sync test-type errors are untouched by this change.