### PR TITLE
chore(api): bump @trakt/api to 0.4.27

### DIFF
--- a/projects/api/deno.json
+++ b/projects/api/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@trakt/api",
   "exports": "./src/index.ts",
-  "version": "0.4.26",
+  "version": "0.4.27",
   "imports": {
     "@anatine/zod-openapi": "npm:@anatine/zod-openapi@^2.2.6",
     "@std/testing": "jsr:@std/testing@^1.0.5",


### PR DESCRIPTION
Bumps `@trakt/api` to 0.4.27 so the smart lists contract merged in #858 can publish. 0.4.26 was already released with the calendar endpoints, so the new surface needs a fresh version to reach JSR.