### PR TITLE
Fixes smart list item schema usage

### DIFF
--- a/projects/api/deno.json
+++ b/projects/api/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@trakt/api",
   "exports": "./mod.ts",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "imports": {
     "@anatine/zod-openapi": "npm:@anatine/zod-openapi@^2.2.6",
     "@std/testing": "jsr:@std/testing@^1.0.5",

--- a/projects/api/src/contracts/_internal/response/smartListItemResponseSchema.ts
+++ b/projects/api/src/contracts/_internal/response/smartListItemResponseSchema.ts
@@ -1,11 +1,11 @@
-import { listedMovieResponseSchema } from './listedMovieResponseSchema.ts';
-import { listedShowResponseSchema } from './listedShowResponseSchema.ts';
+import { movieResponseSchema } from './movieResponseSchema.ts';
+import { showResponseSchema } from './showResponseSchema.ts';
 import { z } from '../z.ts';
 
 /** Zod schema for the smart list item response. */
 export const smartListItemResponseSchema = z.object({
   rank: z.number().int(),
   type: z.string(),
-  movie: listedMovieResponseSchema.nullish(),
-  show: listedShowResponseSchema.nullish(),
+  movie: movieResponseSchema.nullish(),
+  show: showResponseSchema.nullish(),
 });


### PR DESCRIPTION
## 🎶 Notes 🎶
- Updates the `smartListItemResponseSchema` to utilize the more generic `movieResponseSchema` and `showResponseSchema`. This change standardizes the representation of movie and show items within smart lists, ensuring consistency across API responses.
- Bumps the API project version to `0.5.2`.