### PR TITLE
fix(api): restore metadata endpoint type enums

### DIFF
--- a/projects/api/src/contracts/certifications/index.ts
+++ b/projects/api/src/contracts/certifications/index.ts
@@ -6,8 +6,8 @@ import {
 import { showCertificationsResponseSchema } from './schema/showCertificationsResponseSchema.ts';
 
 const certificationTypeParamsSchema = z.object({
-  type: z.string().describe(
-    'Certification media type, typically `movies` or `shows`.',
+  type: z.enum(['movies', 'shows']).describe(
+    'Certification media type.',
   ),
 });
 

--- a/projects/api/src/contracts/countries/index.ts
+++ b/projects/api/src/contracts/countries/index.ts
@@ -2,7 +2,9 @@ import { builder } from '../_internal/builder.ts';
 import { z } from '../_internal/z.ts';
 
 const countryTypeParamsSchema = z.object({
-  type: z.string().describe('Media type to return countries for.'),
+  type: z.enum(['movies', 'shows']).describe(
+    'Media type to return countries for.',
+  ),
 });
 
 /** Zod schema for the country response. */

--- a/projects/api/src/contracts/genres/index.ts
+++ b/projects/api/src/contracts/genres/index.ts
@@ -3,7 +3,9 @@ import { builder } from '../_internal/builder.ts';
 import { z } from '../_internal/z.ts';
 
 const genreTypeParamsSchema = z.object({
-  type: z.string().describe('Media type to return genres for.'),
+  type: z.enum(['movies', 'shows']).describe(
+    'Media type to return genres for.',
+  ),
 });
 
 /** Zod schema for the genre response. */

--- a/projects/api/src/contracts/languages/index.ts
+++ b/projects/api/src/contracts/languages/index.ts
@@ -2,7 +2,9 @@ import { builder } from '../_internal/builder.ts';
 import { z } from '../_internal/z.ts';
 
 const languageTypeParamsSchema = z.object({
-  type: z.string().describe('Media type to return languages for.'),
+  type: z.enum(['movies', 'shows']).describe(
+    'Media type to return languages for.',
+  ),
 });
 
 /** Zod schema for the language response. */


### PR DESCRIPTION
Closes #860.

## What

Restricts the `type` path parameter to `movies` or `shows` for:

- `/languages/{type}`
- `/countries/{type}`
- `/genres/{type}`
- `/certifications/{type}`

This restores the enum metadata in the generated OpenAPI definition and narrows the corresponding client input types.

## Why

These endpoints were modeled with unrestricted strings during the API Blueprint-to-OpenAPI migration, causing the generated documentation to omit their supported values.