### PR TITLE
ci: bump actions/checkout to v5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
       workflows: ${{ steps.changes.outputs.workflows }}
     steps:
       - name: The Oracle's Gaze aka Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: The Seer's Vision aka Filter Paths
         uses: dorny/paths-filter@v3
@@ -45,7 +45,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Summoning the Ancient Scrolls aka Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: The Oracle's Gaze aka Setup Deno
         uses: denoland/setup-deno@v2

--- a/.github/workflows/pr_gate.yml
+++ b/.github/workflows/pr_gate.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Unveiling the Code Codex
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,7 +30,7 @@ jobs:
       id-token: write
     steps:
       - name: The Oracle's Gaze aka Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: The Summoning aka Setup Deno
         uses: denoland/setup-deno@v2


### PR DESCRIPTION
Bumps `actions/checkout` from v4 to v5 across all workflows.

v4 pins Node 20, now deprecated on GitHub-hosted runners and force-run on Node 24. v5 targets Node 24 natively. No behavior change.

Files touched:
- `.github/workflows/ci.yml`
- `.github/workflows/pr_gate.yml`
- `.github/workflows/publish.yml`