### PR TITLE
feat: add letterboxd + mal to the ratings response

### DIFF
--- a/projects/api/src/contracts/_internal/response/movieRatingsResponseSchema.ts
+++ b/projects/api/src/contracts/_internal/response/movieRatingsResponseSchema.ts
@@ -1,0 +1,26 @@
+import { z } from '../z.ts';
+import {
+  externalRatingsResponseSchema,
+  ratingsResponseSchema,
+} from './ratingsResponseSchema.ts';
+
+/**
+ * Zod schema for the movie ratings response - the shared ratings shape plus the
+ * film-specific Letterboxd and MyAnimeList blocks.
+ */
+export const movieRatingsResponseSchema = ratingsResponseSchema.extend({
+  /***
+   * Letterboxd audience rating on a 0-5 scale. Films only.
+   * Available if requesting extended `all`.
+   */
+  letterboxd: externalRatingsResponseSchema.extend({
+    votes: z.number().int().nullish(),
+  }).nullish(),
+  /***
+   * MyAnimeList audience rating on a 0-10 scale. Anime only.
+   * Available if requesting extended `all`.
+   */
+  mal: externalRatingsResponseSchema.extend({
+    votes: z.number().int().nullish(),
+  }).nullish(),
+});

--- a/projects/api/src/contracts/_internal/response/ratingsResponseSchema.ts
+++ b/projects/api/src/contracts/_internal/response/ratingsResponseSchema.ts
@@ -1,7 +1,8 @@
 import { float, z } from '../z.ts';
 import { distributionResponseSchema } from './distributionResponseSchema.ts';
 
-const externalRatingsResponseSchema = z.object({
+/** Shared shape for an external rating source: a rating and a link, both nullish. */
+export const externalRatingsResponseSchema = z.object({
   rating: float(z.number()).nullish(),
   link: z.string().nullish(),
 });

--- a/projects/api/src/contracts/_internal/response/showRatingsResponseSchema.ts
+++ b/projects/api/src/contracts/_internal/response/showRatingsResponseSchema.ts
@@ -1,0 +1,19 @@
+import { z } from '../z.ts';
+import {
+  externalRatingsResponseSchema,
+  ratingsResponseSchema,
+} from './ratingsResponseSchema.ts';
+
+/**
+ * Zod schema for the show ratings response - the shared ratings shape plus the
+ * MyAnimeList block. Letterboxd is films-only, so it is absent here.
+ */
+export const showRatingsResponseSchema = ratingsResponseSchema.extend({
+  /***
+   * MyAnimeList audience rating on a 0-10 scale. Anime only.
+   * Available if requesting extended `all`.
+   */
+  mal: externalRatingsResponseSchema.extend({
+    votes: z.number().int().nullish(),
+  }).nullish(),
+});

--- a/projects/api/src/contracts/movies/index.ts
+++ b/projects/api/src/contracts/movies/index.ts
@@ -30,7 +30,7 @@ import {
   peopleResponseSchema,
 } from '../_internal/response/peopleResponseSchema.ts';
 import { profileResponseSchema } from '../_internal/response/profileResponseSchema.ts';
-import { ratingsResponseSchema } from '../_internal/response/ratingsResponseSchema.ts';
+import { movieRatingsResponseSchema } from '../_internal/response/movieRatingsResponseSchema.ts';
 import { sentimentsResponseSchema } from '../_internal/response/sentimentsResponseSchema.ts';
 import { studioResponseSchema } from '../_internal/response/studioResponseSchema.ts';
 import { translationResponseSchema } from '../_internal/response/translationResponseSchema.ts';
@@ -99,7 +99,7 @@ Returns a single movie's details.
     query: extendedQuerySchemaFactory<['all']>(),
     pathParams: idParamsSchema,
     responses: {
-      200: ratingsResponseSchema,
+      200: movieRatingsResponseSchema,
     },
   },
   stats: {

--- a/projects/api/src/contracts/shows/index.ts
+++ b/projects/api/src/contracts/shows/index.ts
@@ -29,6 +29,7 @@ import { listTypeSchema } from '../_internal/response/listTypeSchema.ts';
 import { peopleResponseSchema } from '../_internal/response/peopleResponseSchema.ts';
 import { profileResponseSchema } from '../_internal/response/profileResponseSchema.ts';
 import { ratingsResponseSchema } from '../_internal/response/ratingsResponseSchema.ts';
+import { showRatingsResponseSchema } from '../_internal/response/showRatingsResponseSchema.ts';
 import { sentimentsResponseSchema } from '../_internal/response/sentimentsResponseSchema.ts';
 import { showCertificationResponseSchema } from '../_internal/response/showCertificationResponseSchema.ts';
 import { showResponseSchema } from '../_internal/response/showResponseSchema.ts';
@@ -288,7 +289,7 @@ Returns a single shows's details. If you request extended info, the \`airs\` obj
     query: extendedQuerySchemaFactory<['all']>(),
     pathParams: idParamsSchema,
     responses: {
-      200: ratingsResponseSchema,
+      200: showRatingsResponseSchema,
     },
   },
   stats: {


### PR DESCRIPTION
Adds `letterboxd` and `mal` blocks to the movie ratings response (`RatingsResponse`), available under `extended=all`, mirroring the existing `tmdb` / `imdb` blocks (`rating` + `link` + `votes`, all nullish).

- **letterboxd**: Letterboxd audience rating, 0-5 scale, films only.
- **mal**: MyAnimeList audience rating, 0-10 scale, anime only.

Both are `nullish` (absent for titles without a score / non-anime). Scales differ per source, documented in the JSDoc, consistent with how the existing blocks already vary (trakt/tmdb/imdb 0-10, metascore/RT 0-100).

The API serves these from dedicated rating columns; the OpenAPI spec regenerates from the schema on build.