### PR TITLE
docs(api): clarify total runtime estimates

### DIFF
--- a/projects/api/src/contracts/_internal/response/showResponseSchema.ts
+++ b/projects/api/src/contracts/_internal/response/showResponseSchema.ts
@@ -47,7 +47,9 @@ export const showResponseSchema = z.object({
   /**
    * Available if requesting extended `full`.
    */
-  total_runtime: z.number().int().nullish(),
+  total_runtime: z.number().int().nullish().describe(
+    'Total runtime in minutes. When exact runtime data is unavailable, this value may include estimated fallback runtimes and should be treated as an approximation.',
+  ),
   /**
    * Available if requesting extended `full`.
    */

--- a/projects/api/src/contracts/shows/schema/response/seasonResponseSchema.ts
+++ b/projects/api/src/contracts/shows/schema/response/seasonResponseSchema.ts
@@ -41,7 +41,9 @@ export const seasonResponseSchema = z.object({
   /**
    * Available if requesting extended `full`.
    */
-  total_runtime: z.number().int().nullish(),
+  total_runtime: z.number().int().nullish().describe(
+    'Total runtime in minutes. When exact runtime data is unavailable, this value may include estimated fallback runtimes and should be treated as an approximation.',
+  ),
   /**
    * Available if requesting extended `full`.
    */


### PR DESCRIPTION
Clarifies that show and season `total_runtime` values can include estimated fallback runtimes when exact runtime data is unavailable.

This helps API clients understand that `total_runtime` should be treated as an approximation rather than an exact sum of the returned runtime fields.

Closes #868