### PR TITLE
fix(search): type search score as double

### DIFF
--- a/projects/api/src/contracts/_internal/z.ts
+++ b/projects/api/src/contracts/_internal/z.ts
@@ -19,6 +19,18 @@ export function float(schema: z.ZodNumber) {
 /**
  * Helper function to mark a number schema as a double in OpenAPI metadata
  */
+export function double(schema: z.ZodNumber) {
+  // Use type assertion to access the openapi method added by extendZodWithOpenApi
+  return (schema as z.ZodNumber & { openapi: (meta: unknown) => z.ZodNumber })
+    .openapi({
+      type: 'number',
+      format: 'double',
+    });
+}
+
+/**
+ * Helper function to mark a number schema as an int64 in OpenAPI metadata
+ */
 export function int64(schema: z.ZodNumber) {
   // Use type assertion to access the openapi method added by extendZodWithOpenApi
   return (schema as z.ZodNumber & { openapi: (meta: unknown) => z.ZodNumber })

--- a/projects/api/src/contracts/search/schema/response/searchListResponseSchema.ts
+++ b/projects/api/src/contracts/search/schema/response/searchListResponseSchema.ts
@@ -1,9 +1,9 @@
-import { int64, z } from '../../../_internal/z.ts';
+import { double, z } from '../../../_internal/z.ts';
 import { listResponseSchema } from '../../../models/index.ts';
 
 /** Zod schema for the search list response. */
 export const searchListResponseSchema = z.object({
-  score: int64(z.number().int()),
+  score: double(z.number()),
   type: z.literal('list'),
   list: listResponseSchema.nullish(),
 });

--- a/projects/api/src/contracts/search/schema/response/searchMovieResponseSchema.ts
+++ b/projects/api/src/contracts/search/schema/response/searchMovieResponseSchema.ts
@@ -1,9 +1,9 @@
 import { movieResponseSchema } from '../../../_internal/response/movieResponseSchema.ts';
-import { int64, z } from '../../../_internal/z.ts';
+import { double, z } from '../../../_internal/z.ts';
 
 /** Zod schema for the search movie response. */
 export const searchMovieResponseSchema = z.object({
-  score: int64(z.number().int()),
+  score: double(z.number()),
   type: z.literal('movie'),
   movie: movieResponseSchema.nullish(),
 });

--- a/projects/api/src/contracts/search/schema/response/searchPersonResponseSchema.ts
+++ b/projects/api/src/contracts/search/schema/response/searchPersonResponseSchema.ts
@@ -1,9 +1,9 @@
-import { int64, z } from '../../../_internal/z.ts';
+import { double, z } from '../../../_internal/z.ts';
 import { personResponseSchema } from '../../../people/schema/response/personResponseSchema.ts';
 
 /** Zod schema for the search person response. */
 export const searchPersonResponseSchema = z.object({
-  score: int64(z.number().int()),
+  score: double(z.number()),
   type: z.literal('person'),
   person: personResponseSchema.nullish(),
 });

--- a/projects/api/src/contracts/search/schema/response/searchShowResponseSchema.ts
+++ b/projects/api/src/contracts/search/schema/response/searchShowResponseSchema.ts
@@ -1,9 +1,9 @@
 import { showResponseSchema } from '../../../_internal/response/showResponseSchema.ts';
-import { int64, z } from '../../../_internal/z.ts';
+import { double, z } from '../../../_internal/z.ts';
 
 /** Zod schema for the search show response. */
 export const searchShowResponseSchema = z.object({
-  score: int64(z.number().int()),
+  score: double(z.number()),
   type: z.literal('show'),
   show: showResponseSchema.nullish(),
 });


### PR DESCRIPTION
## Why

The exact-search handler now scores a hit by confidence instead of returning a constant, emitting fractional bands so clients can rank an unambiguous match above fuzzy results and hold the deep catalog tail below them:

| band | score | meaning |
|---|---|---|
| `certain` | `1` | unique title, or one pinned down by an explicit year |
| `strong` | `0.75` | shares its title but clears the popularity floor |
| `deep` | `0.25` | shares its title, clears no floor |

`score` was annotated `int64`. That is correct for the fuzzy pass, where the value is a Typesense `text_match` magnitude at ~1e17 scale, but it cannot represent the bands above.

Generated consumers take the annotation literally. The Kotlin client decoded the field as `kotlin.Long`, and kotlinx throws on any fractional value:

```
JsonDecodingException: Unexpected JSON token at offset 10:
Unexpected symbol '.' in numeric literal at path: $.score
```

Verified by running that decode against the generated model, not inferred.

## Change

`score` on all four search response shapes (movie, show, person, list) moves from `int64(z.number().int())` to `double(z.number())`. `format: double` still covers the fuzzy magnitudes at the precision JSON already limits them to.

Adds a `double` helper next to `float`/`int64`, and corrects the `int64` doc comment, which described itself as a double. `int64` stays in use for genuine int64 ids (scrobble, trending).

## Verification

- [x] `deno check` on the search contract clean
- [x] `deno task openapi:generate` + `openapi:validate` clean; regenerated spec emits `{"type":"number","format":"double"}` for `score` on `/search/{type}`, `/search/{type}/exact` and `/search/{id_type}/{id}`
- [x] Confirmed downstream: regenerating the Android client off the matching spec change yields `val score: kotlin.Double` and decodes `0.75` / `0.25` / `1`
- [ ] `deno lint` reports 500 pre-existing problems repo-wide (`no-explicit-any` and friends); none in the touched files

## Notes

- Paired client PRs: trakt/trakt-android#309 (spec mirror + weave), trakt/trakt-apple-internal#301 (weave only; its model already decodes `score` as `Double?`).
- Adjacent, not touched: `searchResultResponseSchema` is a `z.union([...])`, which `schemas.md` calls out as the thing to avoid because codegen turns `oneOf` into a model with every member's fields required. That is exactly what the Kotlin client shows today. Worth a separate pass.