### PR TITLE
fix(api): document ratings response variants

### DIFF
--- a/projects/api/src/contracts/_internal/request/extendedRatingsQuerySchema.ts
+++ b/projects/api/src/contracts/_internal/request/extendedRatingsQuerySchema.ts
@@ -1,0 +1,12 @@
+import { z } from '../z.ts';
+
+/** Zod schema for the extended ratings query parameters. */
+export const extendedRatingsQuerySchema = z.object({
+  extended: z
+    .literal('all')
+    .nullish()
+    .openapi({
+      description:
+        'Use `all` to include ratings from supported external sources.',
+    }),
+});

--- a/projects/api/src/contracts/_internal/response/movieRatingsResponseSchema.ts
+++ b/projects/api/src/contracts/_internal/response/movieRatingsResponseSchema.ts
@@ -1,6 +1,8 @@
 import { z } from '../z.ts';
 import {
+  extendedRatingsResponseExample,
   externalRatingsResponseSchema,
+  ratingsResponseExample,
   ratingsResponseSchema,
 } from './ratingsResponseSchema.ts';
 
@@ -9,18 +11,63 @@ import {
  * film-specific Letterboxd and MyAnimeList blocks.
  */
 export const movieRatingsResponseSchema = ratingsResponseSchema.extend({
-  /***
+  /**
    * Letterboxd audience rating on a 0-5 scale. Films only.
    * Available if requesting extended `all`.
    */
   letterboxd: externalRatingsResponseSchema.extend({
     votes: z.number().int().nullish(),
   }).nullish(),
-  /***
+  /**
    * MyAnimeList audience rating on a 0-10 scale. Anime only.
    * Available if requesting extended `all`.
    */
   mal: externalRatingsResponseSchema.extend({
     votes: z.number().int().nullish(),
   }).nullish(),
+}).openapi({
+  mediaExamples: {
+    default: {
+      summary: 'Default response',
+      value: ratingsResponseExample,
+    },
+    extendedAll: {
+      summary: 'Response with `extended=all`',
+      value: {
+        ...extendedRatingsResponseExample,
+        imdb: {
+          link: 'https://www.imdb.com/title/tt37287335',
+          rating: 7.9,
+          votes: 269113,
+        },
+        letterboxd: {
+          link: 'https://letterboxd.com/film/obsession-2025',
+          rating: 4.12,
+          votes: 3633569,
+        },
+        mal: {
+          link: null,
+          rating: null,
+          votes: 0,
+        },
+        metascore: {
+          link: 'https://www.imdb.com/title/tt37287335/criticreviews',
+          rating: 77,
+        },
+        rotten_tomatoes: {
+          link: 'https://www.rottentomatoes.com/m/obsession_2025',
+          rating: 94,
+          state: 'fresh',
+          user_rating: 94,
+          user_state: 'upright',
+        },
+        tmdb: {
+          link: 'https://www.themoviedb.org/movie/1339713',
+          rating: 8.251,
+          votes: 3739,
+        },
+        trakt: ratingsResponseExample,
+      },
+    },
+  },
 });

--- a/projects/api/src/contracts/_internal/response/ratingsResponseSchema.ts
+++ b/projects/api/src/contracts/_internal/response/ratingsResponseSchema.ts
@@ -1,6 +1,65 @@
 import { float, z } from '../z.ts';
 import { distributionResponseSchema } from './distributionResponseSchema.ts';
 
+/** Example of the default Trakt ratings response. */
+export const ratingsResponseExample = {
+  distribution: {
+    1: 143,
+    2: 239,
+    3: 115,
+    4: 483,
+    5: 447,
+    6: 2126,
+    7: 2522,
+    8: 6916,
+    9: 3232,
+    10: 8567,
+  },
+  rating: 8.29481,
+  votes: 24789,
+};
+
+/** Example of the extended ratings shared by all media types. */
+export const extendedRatingsResponseExample = {
+  imdb: {
+    link: 'https://www.imdb.com/title/tt9813792',
+    rating: 7.8,
+    votes: 199521,
+  },
+  metascore: {
+    link: 'https://www.imdb.com/title/tt9813792/criticreviews',
+    rating: 63,
+  },
+  rotten_tomatoes: {
+    link: 'https://www.rottentomatoes.com/tv/from',
+    rating: 96,
+    state: 'fresh',
+    user_rating: 76,
+    user_state: 'upright',
+  },
+  tmdb: {
+    link: 'https://www.themoviedb.org/tv/124364',
+    rating: 8.5,
+    votes: 4037,
+  },
+  trakt: {
+    distribution: {
+      1: 122,
+      2: 87,
+      3: 88,
+      4: 215,
+      5: 673,
+      6: 1102,
+      7: 2599,
+      8: 4266,
+      9: 2285,
+      10: 4491,
+    },
+    rating: 8.11106,
+    votes: 15928,
+  },
+};
+
 /** Shared shape for an external rating source: a rating and a link, both nullish. */
 export const externalRatingsResponseSchema = z.object({
   rating: float(z.number()).nullish(),
@@ -9,31 +68,34 @@ export const externalRatingsResponseSchema = z.object({
 
 /** Zod schema for the ratings response. */
 export const ratingsResponseSchema = z.object({
+  rating: float(z.number()).nullish(),
+  votes: z.number().int().nullish(),
+  distribution: distributionResponseSchema.nullish(),
   trakt: z.object({
     rating: float(z.number()),
     votes: z.number().int(),
     distribution: distributionResponseSchema,
-  }),
-  /***
+  }).nullish(),
+  /**
    * Available if requesting extended `all`.
    */
   tmdb: externalRatingsResponseSchema.extend({
     votes: z.number().int().nullish(),
   }).nullish(),
-  /***
+  /**
    * Available if requesting extended `all`.
    */
   imdb: externalRatingsResponseSchema.extend({
     votes: z.number().int().nullish(),
   }).nullish(),
-  /***
+  /**
    * Available if requesting extended `all`.
    */
   metascore: z.object({
     rating: z.number().int().nullish(),
     link: z.string().nullish(),
-  }),
-  /***
+  }).nullish(),
+  /**
    * Available if requesting extended `all`.
    */
   rotten_tomatoes: externalRatingsResponseSchema.extend({
@@ -41,4 +103,15 @@ export const ratingsResponseSchema = z.object({
     state: z.string().nullish(),
     user_state: z.string().nullish(),
   }).nullish(),
+}).openapi({
+  mediaExamples: {
+    default: {
+      summary: 'Default response',
+      value: ratingsResponseExample,
+    },
+    extendedAll: {
+      summary: 'Response with `extended=all`',
+      value: extendedRatingsResponseExample,
+    },
+  },
 });

--- a/projects/api/src/contracts/_internal/response/showRatingsResponseSchema.ts
+++ b/projects/api/src/contracts/_internal/response/showRatingsResponseSchema.ts
@@ -1,6 +1,8 @@
 import { z } from '../z.ts';
 import {
+  extendedRatingsResponseExample,
   externalRatingsResponseSchema,
+  ratingsResponseExample,
   ratingsResponseSchema,
 } from './ratingsResponseSchema.ts';
 
@@ -9,11 +11,29 @@ import {
  * MyAnimeList block. Letterboxd is films-only, so it is absent here.
  */
 export const showRatingsResponseSchema = ratingsResponseSchema.extend({
-  /***
+  /**
    * MyAnimeList audience rating on a 0-10 scale. Anime only.
    * Available if requesting extended `all`.
    */
   mal: externalRatingsResponseSchema.extend({
     votes: z.number().int().nullish(),
   }).nullish(),
+}).openapi({
+  mediaExamples: {
+    default: {
+      summary: 'Default response',
+      value: ratingsResponseExample,
+    },
+    extendedAll: {
+      summary: 'Response with `extended=all`',
+      value: {
+        ...extendedRatingsResponseExample,
+        mal: {
+          link: null,
+          rating: null,
+          votes: 0,
+        },
+      },
+    },
+  },
 });

--- a/projects/api/src/contracts/movies/index.ts
+++ b/projects/api/src/contracts/movies/index.ts
@@ -4,6 +4,7 @@ import { countryParamsSchema } from '../_internal/request/countryParamsSchema.ts
 import { extendedMediaQuerySchema } from '../_internal/request/extendedMediaQuerySchema.ts';
 import { extendedProfileQuerySchema } from '../_internal/request/extendedProfileQuerySchema.ts';
 import { extendedQuerySchemaFactory } from '../_internal/request/extendedQuerySchemaFactory.ts';
+import { extendedRatingsQuerySchema } from '../_internal/request/extendedRatingsQuerySchema.ts';
 import { extendedWatchNowQuerySchema } from '../_internal/request/extendedWatchNowQuerySchema.ts';
 import { idParamsSchema } from '../_internal/request/idParamsSchema.ts';
 import { ignoreQuerySchema } from '../_internal/request/ignoreQuerySchema.ts';
@@ -93,10 +94,12 @@ Returns a single movie's details.
   ratings: {
     summary: 'Get movie ratings',
     description:
-      'Returns rating (between 0 and 10) and distribution for a movie.',
+      `Returns the Trakt rating (between 0 and 10), vote count, and rating distribution for a movie.
+
+Use \`?extended=all\` to include ratings from TMDB, IMDb, Metascore, Rotten Tomatoes, Letterboxd, and MyAnimeList. External ratings, vote counts, and links can be \`null\` when unavailable.`,
     path: '/ratings',
     method: 'GET',
-    query: extendedQuerySchemaFactory<['all']>(),
+    query: extendedRatingsQuerySchema,
     pathParams: idParamsSchema,
     responses: {
       200: movieRatingsResponseSchema,

--- a/projects/api/src/contracts/shows/index.ts
+++ b/projects/api/src/contracts/shows/index.ts
@@ -4,6 +4,7 @@ import { countryParamsSchema } from '../_internal/request/countryParamsSchema.ts
 import { extendedMediaQuerySchema } from '../_internal/request/extendedMediaQuerySchema.ts';
 import { extendedProfileQuerySchema } from '../_internal/request/extendedProfileQuerySchema.ts';
 import { extendedQuerySchemaFactory } from '../_internal/request/extendedQuerySchemaFactory.ts';
+import { extendedRatingsQuerySchema } from '../_internal/request/extendedRatingsQuerySchema.ts';
 import { extendedWatchNowQuerySchema } from '../_internal/request/extendedWatchNowQuerySchema.ts';
 import { idParamsSchema } from '../_internal/request/idParamsSchema.ts';
 import { ignoreQuerySchema } from '../_internal/request/ignoreQuerySchema.ts';
@@ -114,10 +115,12 @@ Returns a single episode's details. All date and times are in UTC and were calcu
   ratings: {
     summary: 'Get episode ratings',
     description:
-      'Returns rating (between 0 and 10) and distribution for an episode.',
+      `Returns the Trakt rating (between 0 and 10), vote count, and rating distribution for an episode.
+
+Use \`?extended=all\` to include ratings from TMDB, IMDb, Metascore, and Rotten Tomatoes. External ratings, vote counts, and links can be \`null\` when unavailable.`,
     path: '/ratings',
     method: 'GET',
-    query: extendedQuerySchemaFactory<['all']>(),
+    query: extendedRatingsQuerySchema,
     pathParams: idParamsSchema
       .merge(seasonParamsSchema)
       .merge(episodeParamsSchema),
@@ -283,10 +286,12 @@ Returns a single shows's details. If you request extended info, the \`airs\` obj
   ratings: {
     summary: 'Get show ratings',
     description:
-      'Returns rating (between 0 and 10) and distribution for a show.',
+      `Returns the Trakt rating (between 0 and 10), vote count, and rating distribution for a show.
+
+Use \`?extended=all\` to include ratings from TMDB, IMDb, Metascore, Rotten Tomatoes, and MyAnimeList. External ratings, vote counts, and links can be \`null\` when unavailable.`,
     path: '/ratings',
     method: 'GET',
-    query: extendedQuerySchemaFactory<['all']>(),
+    query: extendedRatingsQuerySchema,
     pathParams: idParamsSchema,
     responses: {
       200: showRatingsResponseSchema,
@@ -636,10 +641,12 @@ Returns all lists that contain this season. By default, \`personal\` lists are r
     ratings: {
       summary: 'Get season ratings',
       description:
-        'Returns rating (between 0 and 10) and distribution for a season.',
+        `Returns the Trakt rating (between 0 and 10), vote count, and rating distribution for a season.
+
+Use \`?extended=all\` to include ratings from TMDB, IMDb, Metascore, and Rotten Tomatoes. External ratings, vote counts, and links can be \`null\` when unavailable.`,
       path: '/ratings',
       method: 'GET',
-      query: extendedQuerySchemaFactory<['all']>(),
+      query: extendedRatingsQuerySchema,
       pathParams: idParamsSchema
         .merge(seasonParamsSchema),
       responses: {


### PR DESCRIPTION
## Summary

Correct the ratings endpoint contracts and documentation to represent both
response forms:

- The default response returns `rating`, `votes`, and `distribution` at the top
  level.
- `extended=all` returns a nested `trakt` object plus supported external rating
  providers.

Closes #872 

## Changes

- Constrain the ratings `extended` query parameter to `all`.
- Model both existing response shapes using codegen-safe optional fields.
- Add named `default` and `extendedAll` OpenAPI response examples.
- Document supported providers for movies, shows, seasons, and episodes.
- Mark extended-only provider blocks, including `metascore`, as optional.

## Risk

Low. The response type is widened to represent both payloads already returned
by the API. Generated clients cannot statically select a response shape from a
query parameter, so the two variants are distinguished through named examples
and endpoint documentation.