### PR TITLE
feat(calendar): episode type filter

### DIFF
--- a/projects/api/src/contracts/calendars/index.ts
+++ b/projects/api/src/contracts/calendars/index.ts
@@ -15,6 +15,20 @@ const groupQuery = z.object({
   }),
 });
 
+/*
+  Scoped to the feeds that resolve their own episodes. The dedicated
+  `shows/{new,premieres,finales}` and `releases/hot/*` routes already fix their
+  roles, and `movies` / `streaming` / `dvd` have no episodes to narrow.
+*/
+const episodeTypesQuery = z.object({
+  episode_types: z.string().nullish().openapi({
+    description:
+      `Comma separated list of episode roles: "series_premiere", "season_premiere", "mid_season_premiere", "mid_season_finale", "season_finale", "series_finale".
+      Prefix a role with "-" to exclude it instead, e.g. "-season_finale,-series_finale" drops every finale. Included roles match any of the listed roles; excluded roles must all be absent. Unrecognised values are ignored.
+      On the merged media feed, including a role returns matching episodes only, since a movie carries no episode role; excluding one leaves movies in place.`,
+  }),
+});
+
 /** ts-rest contract for the `calendars` endpoints. */
 export const calendars = builder.router({
   shows: {
@@ -26,7 +40,8 @@ Returns shows airing during the requested UTC date range. Use \`target\` to choo
     query: extendedMediaQuerySchema
       .merge(mediaFilterParamsSchema)
       .merge(ignoreQuerySchema)
-      .merge(groupQuery),
+      .merge(groupQuery)
+      .merge(episodeTypesQuery),
     pathParams: calendarRequestParamsSchema,
     responses: {
       200: calendarShowResponseSchema.array(),
@@ -130,7 +145,8 @@ Returns the merged feed of movies and episodes during the requested UTC date ran
             'Narrow the feed to a single media type. Omit to return both.',
         }),
       }))
-      .merge(groupQuery),
+      .merge(groupQuery)
+      .merge(episodeTypesQuery),
     pathParams: calendarRequestParamsSchema,
     responses: {
       200: hotReleaseResponseSchema.array(),


### PR DESCRIPTION
# Summary

Adds an `episode_types` query filter to the calendar `shows` and `media` endpoints, letting callers narrow (or exclude) episodes by their role in a season's run.

# Details

`episode_types` takes a comma separated list of episode roles: `series_premiere`, `season_premiere`, `mid_season_premiere`, `mid_season_finale`, `season_finale`, `series_finale`. Prefix a role with `-` to exclude it instead. Included roles match any of the listed roles; excluded roles must all be absent. Unrecognised values are ignored.

The filter is scoped to the two feeds that resolve their own episodes. The dedicated `shows/{new,premieres,finales}` and `releases/hot/*` routes already fix their episode roles, and `movies` / `streaming` / `dvd` carry no episodes to narrow.

On the merged `media` feed, including a role returns matching episodes only (a movie carries no episode role), while excluding a role leaves movies in place.

# Example queries

Only season finales airing on my shows calendar this week:

```
GET /calendars/my/shows/2026-07-28/7?episode_types=season_finale
```

All premieres (series or season) on the global shows calendar:

```
GET /calendars/all/shows/2026-07-28/7?episode_types=series_premiere,season_premiere
```

My shows calendar for the month, with every finale dropped:

```
GET /calendars/my/shows/2026-07-28/30?episode_types=-season_finale,-series_finale
```

Merged media feed narrowed to mid-season finale episodes only (movies fall away since a movie has no episode role):

```
GET /calendars/my/media/2026-07-28/7?episode_types=mid_season_finale
```

Merged media feed keeping movies but excluding finale episodes:

```
GET /calendars/all/media/2026-07-28/7?episode_types=-season_finale,-series_finale
```
