### PR TITLE
feat(api): complete the smart list filter and source surface

### DIFF
--- a/projects/api/src/contracts/_internal/request/smartListFiltersSchema.ts
+++ b/projects/api/src/contracts/_internal/request/smartListFiltersSchema.ts
@@ -3,15 +3,22 @@ import { z } from '../z.ts';
 const list = z.array(z.string());
 const range = z.array(z.number()).max(2);
 
+// Applies to the include arm only: 'and' requires every value, 'or' (default)
+// any of them. Exclusion is always "carries none of".
+const operator = z.enum(['and', 'or']);
+
 /** Zod schema for smart list filters. */
 export const smartListFiltersSchema = z.object({
   genres: list.optional(),
+  genres_operator: operator.optional(),
   subgenres: list.optional(),
   certifications: list.optional(),
   languages: list.optional(),
   countries: list.optional(),
   statuses: list.optional(),
   networks: list.optional(),
+  keywords: list.optional(),
+  keywords_operator: operator.optional(),
   watchnow: list.optional(),
   years: range.optional(),
   ratings: range.optional(),
@@ -19,6 +26,14 @@ export const smartListFiltersSchema = z.object({
   imdb_ratings: range.optional(),
   rt_meters: range.optional(),
   rt_user_meters: range.optional(),
+  letterboxd_ratings: range.optional(),
+  mal_ratings: range.optional(),
   ignore_watched: z.boolean().optional(),
   ignore_watchlisted: z.boolean().optional(),
+  ignore_watching: z.boolean().optional(),
+  ignore_unreleased: z.boolean().optional(),
+  ignore_released: z.boolean().optional(),
+  ignore_ended: z.boolean().optional(),
+  ignore_airing: z.boolean().optional(),
+  ignore_no_release_date: z.boolean().optional(),
 });

--- a/projects/api/src/contracts/_internal/request/smartListWriteSchema.ts
+++ b/projects/api/src/contracts/_internal/request/smartListWriteSchema.ts
@@ -10,6 +10,8 @@ export const smartListWriteSchema = z.object({
     'anticipated',
     'recommendations',
     'discover',
+    'watchlist',
+    'library',
   ]),
   media_type: z.enum(['movies', 'shows', 'media']),
   filters: smartListFiltersSchema.optional(),

--- a/projects/api/src/contracts/users/subroutes/smartLists.ts
+++ b/projects/api/src/contracts/users/subroutes/smartLists.ts
@@ -70,7 +70,7 @@ Create a new smart list. A smart list is a dynamic list driven by a \`source\` a
 | Key | Type | Value |
 |---|---|---|
 | \`name\` * | string | Name of the smart list. |
-| \`source\` * | string | \`trending\`, \`popular\`, \`anticipated\`, \`recommendations\`, \`discover\` |
+| \`source\` * | string | \`trending\`, \`popular\`, \`anticipated\`, \`recommendations\`, \`discover\`, \`watchlist\`, \`library\` |
 | \`media_type\` * | string | \`movies\`, \`shows\`, \`media\` |
 | \`filters\` | object | Filter constraints applied to the source. |
 | \`privacy\` | string | \`public\`, \`private\`, \`friends\` |`,


### PR DESCRIPTION
The contract had drifted behind the API. Seven filter dimensions and two sources are live and callable today, but were missing from the schema, so consumers could not send them in a typed request. This closes that gap.

## Filters

Added to `smartListFiltersSchema`:

| Key | Type | Notes |
|---|---|---|
| `genres_operator` | `'and' \| 'or'` | Applies to the include arm only |
| `keywords` | `string[]` | Leading `-` on an entry excludes it, same as the other list filters |
| `keywords_operator` | `'and' \| 'or'` | Applies to the include arm only |
| `letterboxd_ratings` | `[min]` or `[min, max]` | 0-5 scale, films only |
| `mal_ratings` | `[min]` or `[min, max]` | 0-10 scale, anime |
| `ignore_watching` | boolean | |
| `ignore_unreleased` | boolean | |
| `ignore_released` | boolean | |
| `ignore_ended` | boolean | |
| `ignore_airing` | boolean | |
| `ignore_no_release_date` | boolean | |

`and` requires every included value to be present, `or` (the default) any of them. Exclusion is always "carries none of", independent of the operator.

## Sources

`smartListWriteSchema.source` gains `watchlist` and `library`, bringing the enum to the full set of seven. The create-route docs table is updated to match.

## Compatibility

Additive and non-breaking. Every new key is optional, no existing field changes type or shape, and the operators default to `or` server-side when omitted, so existing payloads behave exactly as before.

## Verification

`deno fmt` and `deno lint` clean. `deno task openapi:validate` passes. Parsed a payload carrying every new key through `smartListWriteSchema`: accepted, while an unknown `source` and an invalid operator value are still rejected.

Note that `deno task test` reports 5 pre-existing type errors in `src/contracts/sync/HistoryRequest.test.ts`, which imports a `HistoryRequest` type that has since been renamed to `HistoryAddRequest`. Identical count on `master` before this branch, so it is untouched by this change and left for a separate fix.
