### PR TITLE
feat: add plex server count

### DIFF
--- a/projects/api/src/contracts/users/schema/response/plexSettingsResponseSchema.ts
+++ b/projects/api/src/contracts/users/schema/response/plexSettingsResponseSchema.ts
@@ -107,6 +107,10 @@ export const plexSettingsResponseSchema = z.object({
     error: z.boolean().openapi({
       description: 'Whether a persisted Plex-sync error is currently active.',
     }),
+    server_limit: z.number().int().nullable().openapi({
+      description:
+        'Max number of Plex servers this user may sync. null = unlimited (VIP), 1 = free.',
+    }),
     selection: z.object({
       server_ids: z.string().array(),
       library_ids: plexLibrarySelectionSchema.array(),


### PR DESCRIPTION
# Summary

Adds a `server_limit` field to the Plex sync settings response schema (`plexSettingsResponseSchema`). The field is a nullable integer describing the maximum number of Plex servers the user may sync: `null` means unlimited (VIP) and `1` is the free tier.

# Changes

- `projects/api/src/contracts/users/schema/response/plexSettingsResponseSchema.ts`: add `server_limit` (`z.number().int().nullable()`) with an OpenAPI description, alongside the existing `error` and `selection` fields in the sync settings object.