### PR TITLE
docs(api): fix smart list available options

### DIFF
--- a/projects/api/src/contracts/smart_lists/index.ts
+++ b/projects/api/src/contracts/smart_lists/index.ts
@@ -9,12 +9,6 @@ import { smartListItemResponseSchema } from '../_internal/response/smartListItem
 import { z } from '../_internal/z.ts';
 import { listParamsSchema } from '../users/schema/request/listParamsSchema.ts';
 
-const listItemsPathParamsSchema = listParamsSchema.extend({
-  type: z.string().describe('Smart list item type filter.'),
-  sort_by: z.string().describe('Sort by a specific property.'),
-  sort_how: z.string().describe('Sort direction.'),
-});
-
 /** ts-rest contract for the `smartLists` endpoints. */
 export const smartLists = builder.router({
   summary: {
@@ -36,13 +30,16 @@ Returns a single smart list definition by its globally-unique slug. Use the [**/
     summary: 'Get smart list items',
     description:
       `#### 🔓 OAuth Optional 📄 Pagination ✨ Extended Info 🎚 Filters 😁 Emojis
-Returns the dynamic items a smart list resolves to. Use \`type\`, \`sort_by\`, and \`sort_how\` to control the returned item set and order, plus query filters and pagination to refine the result set.`,
-    path: '/:list_id/items/:type/:sort_by/:sort_how',
+Returns the dynamic items a smart list resolves to. Items always match the list's \`media_type\`, so a movie list only ever resolves to movies and a show list to shows. Use query filters and pagination to refine the result set.`,
+    path: '/:list_id/items',
     method: 'GET',
-    pathParams: listItemsPathParamsSchema,
+    pathParams: listParamsSchema,
     query: extendedMediaQuerySchema
-      .merge(mediaFilterParamsSchema)
-      .merge(ignoreQuerySchema)
+      .merge(mediaFilterParamsSchema.omit({
+        start_date: true,
+        end_date: true,
+      }))
+      .merge(ignoreQuerySchema.omit({ ignore_collected: true }))
       .merge(pageQuerySchema)
       .merge(limitlessQuerySchema),
     responses: {

--- a/projects/api/src/contracts/users/subroutes/smartLists.ts
+++ b/projects/api/src/contracts/users/subroutes/smartLists.ts
@@ -10,7 +10,7 @@ const smartList = builder.router({
   summary: {
     summary: 'Get smart list',
     description: `#### 🔓 OAuth Optional
-Returns a single smart list definition. Use the [**/users/:id/smart-lists/:list_id/items**](#reference/users) method to get the dynamic items this smart list resolves to.`,
+Returns a single smart list definition. Use the [**/smart-lists/:list_id/items**](#reference/smart-lists) method to get the dynamic items this smart list resolves to.`,
     path: '/',
     method: 'GET',
     pathParams: profileParamsSchema.merge(listParamsSchema),
@@ -53,7 +53,7 @@ export const smartLists = builder.router({
   personal: {
     summary: "Get a user's smart lists",
     description: `#### 🔓 OAuth Optional
-Returns all smart list definitions for a user. Use the [**/users/:id/smart-lists/:list_id/items**](#reference/users) method to get the dynamic items a specific smart list resolves to.`,
+Returns all smart list definitions for a user. Use the [**/smart-lists/:list_id/items**](#reference/smart-lists) method to get the dynamic items a specific smart list resolves to.`,
     path: '',
     method: 'GET',
     pathParams: profileParamsSchema,


### PR DESCRIPTION
# Summary

Fixes the smart lists documentation inaccuracies reported in #881. The docs described path and query params the API does not implement, and two endpoints linked to an items method that does not exist.

# Changes

**Fixed broken doc links.** The "Get smart list" and "Get a user's smart lists" descriptions pointed to `/users/:id/smart-lists/:list_id/items`, which was never implemented. Smart list slugs are globally unique, so items are served by the top-level `/smart-lists/:list_id/items` method. Both links now point there.

**Removed the `type`, `sort_by`, and `sort_how` path params from "Get smart list items".** Audited against the worker implementation: the route declares all three as optional and the handler never reads them. They had no effect on the response. A smart list is targeted to a single `media_type`, so its items always match that type and a type filter is not meaningful. The canonical path is now `/smart-lists/:list_id/items`.

**Removed unsupported query params.** `start_date`, `end_date`, and `ignore_collected` are not parsed by the worker's filter handling, so they are omitted from the items query schema. The shared schemas are untouched for other endpoints.

# Verification

- `deno fmt --check` and `deno lint` pass on the edited files
- `deno check` passes on both contract files
- `deno task openapi:validate` passes

Closes #881
