### PR TITLE
fix(api)!: move translations language filter to an optional query param

### DIFF
--- a/projects/api/src/contracts/_internal/request/languageParamsSchema.ts
+++ b/projects/api/src/contracts/_internal/request/languageParamsSchema.ts
@@ -1,6 +1,0 @@
-import { z } from '../z.ts';
-
-/** Zod schema for the language parameters. */
-export const languageParamsSchema = z.object({
-  language: z.string().openapi({ description: '2 character language code' }),
-});

--- a/projects/api/src/contracts/_internal/request/translationsLanguageQuerySchema.ts
+++ b/projects/api/src/contracts/_internal/request/translationsLanguageQuerySchema.ts
@@ -1,0 +1,8 @@
+import { z } from '../z.ts';
+
+/** Zod schema for the translations language query parameters. */
+export const translationsLanguageQuerySchema = z.object({
+  language: z.string().nullish().openapi({
+    description: 'Filter translations to a 2 character language code',
+  }),
+});

--- a/projects/api/src/contracts/movies/index.ts
+++ b/projects/api/src/contracts/movies/index.ts
@@ -8,7 +8,7 @@ import { extendedRatingsQuerySchema } from '../_internal/request/extendedRatings
 import { extendedWatchNowQuerySchema } from '../_internal/request/extendedWatchNowQuerySchema.ts';
 import { idParamsSchema } from '../_internal/request/idParamsSchema.ts';
 import { ignoreQuerySchema } from '../_internal/request/ignoreQuerySchema.ts';
-import { languageParamsSchema } from '../_internal/request/languageParamsSchema.ts';
+import { translationsLanguageQuerySchema } from '../_internal/request/translationsLanguageQuerySchema.ts';
 import { limitlessQuerySchema } from '../_internal/request/limitlessQuerySchema.ts';
 import { linksQuerySchema } from '../_internal/request/linksQuerySchema.ts';
 import { mediaFilterParamsSchema } from '../_internal/request/mediaFilterParamsSchema.ts';
@@ -141,10 +141,11 @@ Use \`?extended=all\` to include ratings from TMDB, IMDb, Metascore, Rotten Toma
   translations: {
     summary: 'Get all movie translations',
     description:
-      'Returns all translations for a movie, including language, country, and translated values for title, tagline and overview. The `country` field can be used together with `language` to identify regional variants (for example `fr`/`fr` vs `fr`/`ca`).',
-    path: '/translations/:language',
+      'Returns all translations for a movie, including language, country, and translated values for title, tagline and overview. The `country` field can be used together with `language` to identify regional variants (for example `fr`/`fr` vs `fr`/`ca`). Use the optional `language` query param to filter to a single language.',
+    path: '/translations',
     method: 'GET',
-    pathParams: idParamsSchema.merge(languageParamsSchema),
+    pathParams: idParamsSchema,
+    query: translationsLanguageQuerySchema,
     responses: {
       200: translationResponseSchema,
     },

--- a/projects/api/src/contracts/shows/index.ts
+++ b/projects/api/src/contracts/shows/index.ts
@@ -8,7 +8,7 @@ import { extendedRatingsQuerySchema } from '../_internal/request/extendedRatings
 import { extendedWatchNowQuerySchema } from '../_internal/request/extendedWatchNowQuerySchema.ts';
 import { idParamsSchema } from '../_internal/request/idParamsSchema.ts';
 import { ignoreQuerySchema } from '../_internal/request/ignoreQuerySchema.ts';
-import { languageParamsSchema } from '../_internal/request/languageParamsSchema.ts';
+import { translationsLanguageQuerySchema } from '../_internal/request/translationsLanguageQuerySchema.ts';
 import { limitlessQuerySchema } from '../_internal/request/limitlessQuerySchema.ts';
 import { linksQuerySchema } from '../_internal/request/linksQuerySchema.ts';
 import { mediaFilterParamsSchema } from '../_internal/request/mediaFilterParamsSchema.ts';
@@ -90,13 +90,13 @@ Returns a single episode's details. All date and times are in UTC and were calcu
   translations: {
     summary: 'Get all episode translations',
     description:
-      'Returns all translations for an episode, including language, country, and translated values for title and overview. The `country` field can be used together with `language` to identify regional variants (for example `fr`/`fr` vs `fr`/`ca`).',
-    path: '/translations/:language',
+      'Returns all translations for an episode, including language, country, and translated values for title and overview. The `country` field can be used together with `language` to identify regional variants (for example `fr`/`fr` vs `fr`/`ca`). Use the optional `language` query param to filter to a single language.',
+    path: '/translations',
     method: 'GET',
     pathParams: idParamsSchema
       .merge(seasonParamsSchema)
-      .merge(episodeParamsSchema)
-      .merge(languageParamsSchema),
+      .merge(episodeParamsSchema),
+    query: translationsLanguageQuerySchema,
     responses: {
       200: episodeTranslationResponseSchema,
     },
@@ -397,10 +397,11 @@ By default, the \`last_episode\` and \`next_episode\` are calculated using the l
   translations: {
     summary: 'Get all show translations',
     description:
-      'Returns all translations for a show, including language, country, and translated values for title, tagline and overview. The `country` field can be used together with `language` to identify regional variants (for example `fr`/`fr` vs `fr`/`ca`).',
-    path: '/translations/:language',
+      'Returns all translations for a show, including language, country, and translated values for title, tagline and overview. The `country` field can be used together with `language` to identify regional variants (for example `fr`/`fr` vs `fr`/`ca`). Use the optional `language` query param to filter to a single language.',
+    path: '/translations',
     method: 'GET',
-    pathParams: idParamsSchema.merge(languageParamsSchema),
+    pathParams: idParamsSchema,
+    query: translationsLanguageQuerySchema,
     responses: {
       200: translationResponseSchema,
     },
@@ -581,12 +582,12 @@ If you'd like to included translated episode titles and overviews in the respons
     translations: {
       summary: 'Get all season translations',
       description:
-        'Returns all translations for a season, including language, country, and translated title and overview values.',
-      path: '/translations/:language',
+        'Returns all translations for a season, including language, country, and translated title and overview values. Use the optional `language` query param to filter to a single language.',
+      path: '/translations',
       method: 'GET',
       pathParams: idParamsSchema
-        .merge(seasonParamsSchema)
-        .merge(languageParamsSchema),
+        .merge(seasonParamsSchema),
+      query: translationsLanguageQuerySchema,
       responses: {
         200: translationResponseSchema,
       },


### PR DESCRIPTION
# Summary

Models the `language` filter on the translations endpoints as an optional query param instead of a required path param. Refs #869: OpenAPI cannot represent an optional path segment, so the generated docs incorrectly showed `language` as required on `GET /translations/{language}`. The API now accepts `?language=` (trakt/trakt-rails#2386), which the contract can document accurately.

# Changes

- The movie, show, season, and episode translations routes change from `path: '/translations/:language'` with a required path param to `path: '/translations'` with an optional `language` query param.
- New shared `translationsLanguageQuerySchema` (`language` nullish, "Filter translations to a 2 character language code"), modeled on the existing comments `languageQuerySchema`.
- `languageParamsSchema` had no remaining users and was internal only (never exported from the barrel), so it is removed.
- Each route description now notes the optional `language` query param.

# Why a version bump to 0.6.0

This is a breaking change to the typed client surface: `language` moves from `params` to `query` on the four translations routes, so existing callers passing `params: { id, language }` fail type-checking until they migrate to `query: { language }`. The generated client also changes what it sends on the wire, from `/translations/{language}` to `/translations?language=`. Under 0.x semver the minor bump (0.5.x to 0.6.0) is the breaking signal. Publishing is tag-driven, so after merge this ships by pushing a `v0.6.0` tag (`deno.json` stays at the `0.0.0` placeholder per the publish workflow).

# Deploy order

Rails must deploy first: until trakt/trakt-rails#2386 is live, `?language=` is ignored and a filtered call would silently return all translations. Sequence: deploy Rails, tag `v0.6.0` to publish, then bump consumers (trakt-web has three call sites to migrate).

# Migration

```ts
// before
traktApi.movies.translations({ params: { id, language } });

// after
traktApi.movies.translations({ params: { id }, query: { language } });
```

# Verification

- `deno fmt` / `deno lint` clean.
- `deno task openapi:validate` passes; the generated spec now shows `language` as a non-required query param on all four endpoints.
- `deno task publish:check` passes (no slow types).
- `deno task test` fails with 5 pre-existing type errors in `sync/HistoryRequest.test.ts`; master fails identically, unrelated to this change.
