### PR TITLE
docs(api): use PKCE for ReadMe docs OAuth

### DIFF
--- a/projects/openapi/generate.ts
+++ b/projects/openapi/generate.ts
@@ -89,6 +89,9 @@ export function generate(): ReturnType<typeof generateOpenApi> {
         },
       },
       'x-readme': {
+        'oauth-options': {
+          usePkce: true,
+        },
         headers: [
           {
             key: 'User-Agent',


### PR DESCRIPTION
# Summary

The Re-Authorize / Try It OAuth flow on docs.trakt.tv fails with a generic Authorization Error popup after authorizing (refs #878). ReadMe's default authorization code exchange sends the client credentials via HTTP Basic authentication, which auth.trakt.tv does not accept, so the code-for-token exchange 400s and ReadMe surfaces the generic error.

This adds ReadMe's `oauth-options` to the root `x-readme` block with `usePkce: true`. With PKCE enabled, ReadMe replaces the client secret with a code verifier sent in the request body alongside the client_id, which is the exchange shape auth.trakt.tv supports. It also means developer client secrets never route through ReadMe.

# Workaround

Until the docs OAuth flow is fully restored, developers testing from the docs must add `https://docs.trakt.tv/oauth2-redirect` to their app's Redirect URIs at https://app.trakt.tv/settings/apps/api. That is the callback URL ReadMe sends as the `redirect_uri` for the docs Try It flow, and it currently must be registered on the app for the authorize step to pass.

# Testing

- `deno task openapi:generate` regenerates the spec with the new `oauth-options` block
- `deno task openapi:validate`, `deno fmt --check`, and `deno lint` pass