### PR TITLE
feat(show): adds last_aired to the show response

### DIFF
--- a/projects/api/src/contracts/_internal/response/showResponseSchema.ts
+++ b/projects/api/src/contracts/_internal/response/showResponseSchema.ts
@@ -34,6 +34,13 @@ export const showResponseSchema = z.object({
   first_aired: z.string().nullish(),
   /**
    * Available if requesting extended `full`.
+   *
+   * The air date of the most recently aired episode. `null` until the show
+   * has aired an episode.
+   */
+  last_aired: z.string().nullish(),
+  /**
+   * Available if requesting extended `full`.
    */
   airs: z.object({
     day: z.string().nullish(),


### PR DESCRIPTION
## 🎶 Notes 🎶

- Adds `last_aired` to the show response, the air date of the most recently aired episode. Served by trakt-workers since [redacted]
  - nullish, so `null` until the show has aired something. Plain `z.string()` to match `first_aired`