### PR TITLE
feat(api)!: add /sync/playback and /sync/playback/episodes

### DIFF
--- a/projects/api/src/contracts/sync/index.ts
+++ b/projects/api/src/contracts/sync/index.ts
@@ -29,12 +29,14 @@ import {
   collectedShowSchema,
   collectionResponseSchema,
 } from './schema/response/collectionResponseSchema.ts';
+import { episodeProgressResponseSchema } from './schema/response/episodeProgressResponseSchema.ts';
 import { favoritesRemoveResponseSchema } from './schema/response/favoritesRemoveResponseSchema.ts';
 import { favoritesResponseSchema } from './schema/response/favoritesResponseSchema.ts';
 import { historyRemoveResponseSchema } from './schema/response/historyRemoveResponseSchema.ts';
 import { historyResponseSchema } from './schema/response/historyResponseSchema.ts';
 import { lastActivitiesResponseSchema } from './schema/response/lastActivitiesResponseSchema.ts';
 import { movieProgressResponseSchema } from './schema/response/movieProgressResponseSchema.ts';
+import { playbackResponseSchema } from './schema/response/playbackResponseSchema.ts';
 import { ratingsSyncResponseSchema } from './schema/response/ratingsResponseSchema.ts';
 import { removeRatingsResponseSchema } from './schema/response/removeRatingsResponseSchema.ts';
 import { upNextResponseSchema } from './schema/response/upNextResponseSchema.ts';
@@ -100,6 +102,9 @@ const syncReorderResponseSchema = z.object({
   skipped_ids: z.array(z.number().int()).optional(),
 }).passthrough();
 
+const PLAYBACK_PAGINATION_NOTE =
+  `Pagination is opt-in: without \`page\` or \`limit\` the whole set is returned and no \`X-Pagination-*\` headers are sent. Sending either paginates and adds the headers.`;
+
 const progress = builder.router({
   upNext: {
     standard: {
@@ -135,30 +140,48 @@ Returns the authenticated user up next progress optimized for intent-based clien
   movies: {
     summary: 'Get movie playback progress',
     description: `#### 🔒 OAuth Required 📄 Pagination Optional ✨ Extended Info
-Returns in-progress movie playback items for the authenticated user. Use \`start_at\` and \`end_at\` to filter progress updated within a UTC datetime range.`,
+Returns in-progress movie playback items for the authenticated user, most recently paused first. Use \`start_at\` and \`end_at\` to filter on \`paused_at\` within a UTC datetime range.
+
+${PLAYBACK_PAGINATION_NOTE}`,
     method: 'GET',
     path: '/playback/movies',
-    query: extendedQuerySchemaFactory<['full', 'images', 'available_on']>()
-      .merge(mediaFilterParamsSchema)
+    query: extendedQuerySchemaFactory<['full', 'images']>()
       .merge(pageQuerySchema)
       .merge(progressParamsSchema),
     responses: {
       200: movieProgressResponseSchema.array(),
     },
   },
-  playback: {
-    summary: 'Get playback progress',
+  episodes: {
+    summary: 'Get episode playback progress',
     description: `#### 🔒 OAuth Required 📄 Pagination Optional ✨ Extended Info
-Returns playback progress for the requested media \`type\`. Use \`start_at\` and \`end_at\` to filter progress updated within a UTC datetime range.`,
+Returns in-progress episode playback items for the authenticated user, most recently paused first. Each item carries the parent \`show\`. Use \`start_at\` and \`end_at\` to filter on \`paused_at\` within a UTC datetime range.
+
+${PLAYBACK_PAGINATION_NOTE}`,
     method: 'GET',
-    path: '/playback/:type',
-    pathParams: syncTypeParamsSchema,
-    query: extendedQuerySchemaFactory<['full', 'images', 'available_on']>()
-      .merge(mediaFilterParamsSchema)
+    path: '/playback/episodes',
+    query: extendedQuerySchemaFactory<['full', 'images']>()
       .merge(pageQuerySchema)
       .merge(progressParamsSchema),
     responses: {
-      200: movieProgressResponseSchema.array(),
+      200: episodeProgressResponseSchema.array(),
+    },
+  },
+  playback: {
+    summary: 'Get playback progress',
+    description: `#### 🔒 OAuth Required 📄 Pagination Optional ✨ Extended Info
+Returns in-progress movie and episode playback items for the authenticated user, most recently paused first. Use \`start_at\` and \`end_at\` to filter on \`paused_at\` within a UTC datetime range.
+
+Discriminate on \`type\`: movie items carry \`movie\`, episode items carry \`episode\` and the parent \`show\`.
+
+${PLAYBACK_PAGINATION_NOTE}`,
+    method: 'GET',
+    path: '/playback',
+    query: extendedQuerySchemaFactory<['full', 'images']>()
+      .merge(pageQuerySchema)
+      .merge(progressParamsSchema),
+    responses: {
+      200: playbackResponseSchema.array(),
     },
   },
   drop: {
@@ -695,6 +718,7 @@ export {
   collectionMinimalShowResponseSchema,
   collectionParamSchema,
   collectionResponseSchema,
+  episodeProgressResponseSchema,
   favoriteParamSchema,
   favoritesRemoveResponseSchema,
   favoritesResponseSchema,
@@ -703,6 +727,7 @@ export {
   lastActivitiesResponseSchema,
   minimalParamSchema,
   movieProgressResponseSchema,
+  playbackResponseSchema,
   ratingsParamSchema,
   ratingsSyncResponseSchema,
   removeRatingsParamSchema,
@@ -712,8 +737,14 @@ export {
 
 /** The up next response payload. */
 export type UpNextResponse = z.infer<typeof upNextResponseSchema>;
+/** The episode progress response payload. */
+export type EpisodeProgressResponse = z.infer<
+  typeof episodeProgressResponseSchema
+>;
 /** The movie progress response payload. */
 export type MovieProgressResponse = z.infer<typeof movieProgressResponseSchema>;
+/** The playback progress response payload. */
+export type PlaybackResponse = z.infer<typeof playbackResponseSchema>;
 /** The up next intent request payload. */
 export type UpNextIntentRequest = z.infer<typeof upNextIntentQuerySchema>;
 

--- a/projects/api/src/contracts/sync/schema/response/episodeProgressResponseSchema.ts
+++ b/projects/api/src/contracts/sync/schema/response/episodeProgressResponseSchema.ts
@@ -1,0 +1,11 @@
+import { episodeResponseSchema } from '../../../_internal/response/episodeResponseSchema.ts';
+import { showResponseSchema } from '../../../_internal/response/showResponseSchema.ts';
+import { z } from '../../../_internal/z.ts';
+import { playbackItemResponseSchema } from './playbackItemResponseSchema.ts';
+
+/** Zod schema for the episode progress response. */
+export const episodeProgressResponseSchema = playbackItemResponseSchema.extend({
+  type: z.literal('episode'),
+  episode: episodeResponseSchema,
+  show: showResponseSchema,
+});

--- a/projects/api/src/contracts/sync/schema/response/movieProgressResponseSchema.ts
+++ b/projects/api/src/contracts/sync/schema/response/movieProgressResponseSchema.ts
@@ -1,12 +1,9 @@
 import { z } from 'zod';
-import { float, int64 } from '../../../_internal/z.ts';
 import { movieResponseSchema } from '../../../movies/index.ts';
+import { playbackItemResponseSchema } from './playbackItemResponseSchema.ts';
 
 /** Zod schema for the movie progress response. */
-export const movieProgressResponseSchema = z.object({
-  progress: float(z.number().min(0).max(100)),
-  paused_at: z.string().datetime(),
-  id: int64(z.number().int()),
+export const movieProgressResponseSchema = playbackItemResponseSchema.extend({
   type: z.literal('movie'),
   movie: movieResponseSchema,
 });

--- a/projects/api/src/contracts/sync/schema/response/playbackItemResponseSchema.ts
+++ b/projects/api/src/contracts/sync/schema/response/playbackItemResponseSchema.ts
@@ -1,0 +1,8 @@
+import { float, int64, z } from '../../../_internal/z.ts';
+
+/** Zod schema for the fields shared by every playback progress item. */
+export const playbackItemResponseSchema = z.object({
+  progress: float(z.number().min(0).max(100)),
+  paused_at: z.string().datetime(),
+  id: int64(z.number().int()),
+});

--- a/projects/api/src/contracts/sync/schema/response/playbackResponseSchema.ts
+++ b/projects/api/src/contracts/sync/schema/response/playbackResponseSchema.ts
@@ -1,0 +1,20 @@
+import { episodeResponseSchema } from '../../../_internal/response/episodeResponseSchema.ts';
+import { movieResponseSchema } from '../../../_internal/response/movieResponseSchema.ts';
+import { showResponseSchema } from '../../../_internal/response/showResponseSchema.ts';
+import { z } from '../../../_internal/z.ts';
+import { playbackItemResponseSchema } from './playbackItemResponseSchema.ts';
+
+/**
+ * A single paused playback item: a movie OR an episode. Modeled as one flat
+ * object with every shape-specific field nullish rather than a `z.union` -
+ * OpenAPI codegen turns a union `oneOf` into a model with all fields required,
+ * so consumers get a wrong schema. With nullish fields the generated model is
+ * correct; discriminate on `type` (movie items carry `movie`, episode items
+ * carry `episode` and the parent `show`).
+ */
+export const playbackResponseSchema = playbackItemResponseSchema.extend({
+  type: z.enum(['movie', 'episode']),
+  movie: movieResponseSchema.nullish(),
+  episode: episodeResponseSchema.nullish(),
+  show: showResponseSchema.nullish(),
+});


### PR DESCRIPTION
## Summary
- Documents the bare `/sync/playback` route and adds `/sync/playback/episodes`, alongside the existing `/sync/playback/movies`, each with a precise response.
- Replaces the templated `/sync/playback/:type` route, which duplicated the movies route and mistyped episode items, and drops query params the endpoint doesn't accept.

## Breaking change
- `/sync/playback/:type` is removed in favor of the bare `/sync/playback` route.
- The `/sync/playback` response schema loosens `movie`/`episode`/`show` to nullish fields, discriminated by `type`.