### PR TITLE
fix: reuse existing id schema for hide recommendation

### DIFF
--- a/projects/api/src/contracts/_internal/request/idParamsSchema.ts
+++ b/projects/api/src/contracts/_internal/request/idParamsSchema.ts
@@ -3,6 +3,6 @@ import { z } from '../z.ts';
 /** Zod schema for the id parameters. */
 export const idParamsSchema = z.object({
   id: z.string().openapi({
-    description: 'The slug of the resource.',
+    description: 'The id/slug of the resource.',
   }),
 });

--- a/projects/api/src/contracts/recommendations/index.ts
+++ b/projects/api/src/contracts/recommendations/index.ts
@@ -2,10 +2,10 @@ import { authMetadata, builder } from '../_internal/builder.ts';
 import { extendedMediaQuerySchema } from '../_internal/request/extendedMediaQuerySchema.ts';
 import { mediaFilterParamsSchema } from '../_internal/request/mediaFilterParamsSchema.ts';
 import { z } from '../_internal/z.ts';
-import { hideParamsSchema } from './schema/request/hideParamsSchema.ts';
 import { recommendationsQuerySchema } from './schema/request/recommendationsQuerySchema.ts';
 import { recommendedMovieResponse } from './schema/response/recommendedMovieResponse.ts';
 import { recommendedShowResponse } from './schema/response/recommendedShowResponse.ts';
+import { idParamsSchema } from "../_internal/request/idParamsSchema.ts";
 
 const movies = builder.router({
   recommend: {
@@ -29,7 +29,7 @@ The \`favorited_by\` array contains all users who favorited the item along with 
 Hide a movie from getting recommended anymore.`,
     path: '/:id',
     method: 'DELETE',
-    pathParams: hideParamsSchema,
+    pathParams: idParamsSchema,
     responses: {
       204: z.undefined(),
     },
@@ -58,7 +58,7 @@ The \`favorited_by\` array contains all users who favorited the item along with 
 Hide a show from getting recommended anymore.`,
     path: '/:id',
     method: 'DELETE',
-    pathParams: hideParamsSchema,
+    pathParams: idParamsSchema,
     responses: {
       204: z.undefined(),
     },
@@ -73,10 +73,6 @@ export const recommendations = builder.router({
   pathPrefix: '/recommendations',
   metadata: authMetadata('required'),
 });
-
-export { hideParamsSchema };
-/** The hide recommendation parameters. */
-export type HideRecommendationParams = z.infer<typeof hideParamsSchema>;
 
 export { recommendedMovieResponse };
 /** The recommended movie response payload. */

--- a/projects/api/src/contracts/recommendations/schema/request/hideParamsSchema.ts
+++ b/projects/api/src/contracts/recommendations/schema/request/hideParamsSchema.ts
@@ -1,8 +1,0 @@
-import { z } from '../../../_internal/z.ts';
-
-/** Zod schema for the hide parameters. */
-export const hideParamsSchema = z.object({
-  id: z.number().int().or(z.string()).describe(
-    'Trakt ID, Trakt slug, or IMDB ID Example: 922.',
-  ),
-});


### PR DESCRIPTION
- currently generating invalid empty class param