### PR TITLE
fix(api): add missing user stats response fields

### DIFF
--- a/projects/api/src/contracts/users/UserStatsResponse.test.ts
+++ b/projects/api/src/contracts/users/UserStatsResponse.test.ts
@@ -1,0 +1,64 @@
+import { assertType, type IsExact } from '@std/testing/types';
+
+import type { UserStatsResponse } from './index.ts';
+
+Deno.test('@types/UserStatsResponse: complete stats response', () => {
+  const stats: UserStatsResponse = {
+    movies: {
+      plays: 1845,
+      watched: 1743,
+      minutes: 206432,
+      collected: 0,
+      ratings: 438,
+      comments: 46,
+    },
+    shows: {
+      watched: 686,
+      collected: 0,
+      ratings: 98,
+      comments: 10,
+    },
+    seasons: {
+      ratings: 16,
+      comments: 2,
+    },
+    episodes: {
+      plays: 10628,
+      watched: 10595,
+      minutes: 412517,
+      collected: 0,
+      ratings: 276,
+      comments: 88,
+    },
+    network: {
+      friends: 19,
+      followers: 731,
+      following: 28,
+    },
+    ratings: {
+      total: 828,
+      distribution: {
+        1: 0,
+        2: 1,
+        3: 0,
+        4: 13,
+        5: 39,
+        6: 99,
+        7: 159,
+        8: 212,
+        9: 184,
+        10: 121,
+      },
+    },
+    progress: {
+      started: 388,
+      finished: 276,
+      dropped: 22,
+    },
+    lists: 31,
+    total_minutes: 618949,
+    total_plays: 12473,
+  };
+
+  assertType<IsExact<typeof stats, UserStatsResponse>>(true);
+});

--- a/projects/api/src/contracts/users/schema/response/userStatsResponseSchema.ts
+++ b/projects/api/src/contracts/users/schema/response/userStatsResponseSchema.ts
@@ -31,4 +31,12 @@ export const userStatsResponseSchema = z.object({
     total: z.number().int(),
     distribution: distributionResponseSchema,
   }),
+  progress: z.object({
+    started: z.number().int(),
+    finished: z.number().int(),
+    dropped: z.number().int(),
+  }),
+  lists: z.number().int(),
+  total_minutes: z.number().int(),
+  total_plays: z.number().int(),
 });


### PR DESCRIPTION
## Summary

Update the `GET /users/{id}/stats` response schema to match the fields returned by the API.

Closes #910.

## Changes

- Add `progress.started`, `progress.finished`, and `progress.dropped`
- Add `lists`, `total_minutes`, and `total_plays`
- Add a type regression test based on an actual API response

## Risk

Low. This expands the documented response contract with fields already returned by the API.