### PR TITLE
docs(api): document the limit constraints on paginated endpoints

### DIFF
--- a/projects/api/src/contracts/_internal/request/pageQuerySchema.ts
+++ b/projects/api/src/contracts/_internal/request/pageQuerySchema.ts
@@ -7,6 +7,6 @@ export const pageQuerySchema = z.object({
   }),
   limit: z.number().int().nullish().openapi({
     description:
-      'The number of items per page. The default varies per endpoint, so send an explicit value rather than relying on it. The maximum is 250; a larger value is clamped to it rather than rejected.',
+      'The number of items per page. Defaults and maximums vary by endpoint. When pagination parameters are omitted, a low default limit is applied (often 10). When a limit is provided, it is capped at the endpoint maximum (often 250); higher values are clamped rather than rejected.',
   }),
 });

--- a/projects/api/src/contracts/_internal/request/pageQuerySchema.ts
+++ b/projects/api/src/contracts/_internal/request/pageQuerySchema.ts
@@ -6,6 +6,7 @@ export const pageQuerySchema = z.object({
     description: 'The page number to retrieve',
   }),
   limit: z.number().int().nullish().openapi({
-    description: 'The number of items per page',
+    description:
+      'The number of items per page. The default varies per endpoint, so send an explicit value rather than relying on it. The maximum is 250; a larger value is clamped to it rather than rejected.',
   }),
 });


### PR DESCRIPTION
Fixes #924.

The [pagination guide](https://docs.trakt.tv/docs/pagination) tells readers that every paginated method defaults to 10 items per page, and the reference pages generated from this repo mention no default and no maximum at all, because `pageQuerySchema` describes `limit` as just "The number of items per page".

Neither matches the API. Sending no `limit` and reading `X-Pagination-Limit` back:

| Endpoint | `X-Pagination-Limit` |
| --- | --- |
| `/users/{id}/history` | 100 |
| `/movies/trending`, `/movies/popular`, `/movies/anticipated` | 100 |
| `/shows/trending`, `/shows/popular` | 100 |
| `/users/{id}/watchlist`, `/users/{id}/lists` | 100 |
| `/movies/{id}/lists`, `/shows/{id}/lists` | 100 |
| `/search/{type}` | 50 |
| `/movies/{id}/comments`, `/shows/{id}/comments` | 10 |

The maximum on every endpoint I tested has been 250 since June 15, and a larger value is clamped to it rather than rejected:

| requested `limit` | `X-Pagination-Limit` | items returned |
| --- | --- | --- |
| 250 | 250 | 250 |
| 500 | 250 | 250 |
| 1000 | 250 | 250 |

I hit this in a plugin of mine. It asked for the page count without a `limit`, got a count back for 100-item pages, then walked those pages at `limit=10`, and imported a tenth of my history.

`pageQuerySchema` is shared by endpoints whose defaults and maximums disagree, so this does not state either as a rule. It says that both vary by endpoint, gives the common values, and spells out that an oversized limit is clamped rather than rejected.

## What this deliberately leaves alone

- The prose guide on docs.trakt.tv, which does not appear to live in this repo.
- `recommendationsQuerySchema`, which has its own separate `limit`.
- `limitlessQuerySchema`, where `limit` can also be the value `all`.
- Validation behaviour. This is a description change only, so nothing that used to be accepted is now rejected. I left `.max(250)` off on purpose, since #775 notes the effective page size can be lower for heavier `extended` modes, and a hard schema constraint would claim more than I can verify.

## Pull Request Checklist

- [x] **Clear and Concise Title**
- [x] **Detailed Description**
- [ ] **Tests:** description-only change, no behaviour to test. The generated spec was checked by hand for the new text.
- [x] **Coding Standards**
- [x] **Commit Messages:** Conventional Commits, `docs(api)`
- [x] **Documentation:** this is the documentation change
- [x] **Code Review**

