### PR TITLE
feat(api): add gif to the comment response

### DIFF
--- a/projects/api/src/contracts/_internal/response/commentResponseSchema.ts
+++ b/projects/api/src/contracts/_internal/response/commentResponseSchema.ts
@@ -8,6 +8,7 @@ export const commentResponseSchema = z.object({
   created_at: z.string().datetime(),
   updated_at: z.string().datetime(),
   comment: z.string(),
+  gif: z.string().nullish(),
   spoiler: z.boolean(),
   review: z.boolean(),
   replies: z.number().int(),


### PR DESCRIPTION
Clients drop a Klipy link into the comment text; the server lifts it onto its own column and returns it here.

Needed by trakt-web's GIF picker, which currently patches the field in locally.